### PR TITLE
Fix CircleCI devnet test exit code

### DIFF
--- a/.circleci/runtest.bash
+++ b/.circleci/runtest.bash
@@ -1,1 +1,4 @@
-yarn run test --reporter mocha-multi-reporters --reporter-options configFile=.circleci/mocha.json; echo $? > devnet || true
+yarn run test --reporter mocha-multi-reporters --reporter-options configFile=.circleci/mocha.json
+test_exit_code=$?
+echo "$test_exit_code" > devnet
+exit "$test_exit_code"


### PR DESCRIPTION
A success was being returned from the Devnet tests despite not all tests passing. This PR fixes the issue.