### PR TITLE
Check for pending status when skipping confirmation check

### DIFF
--- a/src/shiftIn.ts
+++ b/src/shiftIn.ts
@@ -69,7 +69,11 @@ export class ShiftInObject {
             try {
                 // Check if the darknodes have already seen the transaction
                 const queryTxResponse = await this.queryTx();
-                if (queryTxResponse.txStatus === TxStatus.TxStatusDone || queryTxResponse.txStatus === TxStatus.TxStatusExecuting) {
+                if (
+                    queryTxResponse.txStatus === TxStatus.TxStatusDone ||
+                    queryTxResponse.txStatus === TxStatus.TxStatusExecuting ||
+                    queryTxResponse.txStatus === TxStatus.TxStatusPending
+                ) {
                     // Shift has already been submitted to RenVM - no need to
                     // wait for deposit.
                     return this;


### PR DESCRIPTION
Currently, we skip the tx confirmation check if the trade is already `done` or `executing`. This PR adds the same condition for the `pending` status.