### PR TITLE
Add "transferUpdated" event to GatewayJS

### DIFF
--- a/packages/lib/ren-interfaces/src/messages.ts
+++ b/packages/lib/ren-interfaces/src/messages.ts
@@ -21,6 +21,8 @@ export enum GatewayMessageType {
 
     Status = "status",
     GetStatus = "getStatus",
+    TransferUpdated = "transferUpdated",
+
     Cancel = "cancel",
     Error = "error",
     Done = "done",
@@ -58,6 +60,7 @@ export type GatewayMessagePayload<Type extends GatewayMessageType> =
         details: null;
     } :
     Type extends GatewayMessageType.GetStatus ? {} :
+    Type extends GatewayMessageType.TransferUpdated ? { transfer: HistoryEvent } :
     Type extends GatewayMessageType.Cancel ? {} :
     Type extends GatewayMessageType.Error ? {
         message: string;

--- a/packages/ui/gateway-example/src/main.tsx
+++ b/packages/ui/gateway-example/src/main.tsx
@@ -58,7 +58,12 @@ const startShiftIn = async (web3: Web3, gatewayJS: GatewayJS, amount: string, et
     // }
 
     const result = await gatewayJS.open(shiftInParams).result()
-        .on("status", (status) => { console.debug(`[GOT STATUS] ${status}`); });
+        .on("status", (status) => { console.debug(`[GOT STATUS] ${status}`); })
+        .on("transferUpdated", (transfer) => {
+            console.group(`[GOT TRANSFER]`);
+            console.debug(transfer);
+            console.groupEnd();
+        });
 
     console.debug(result);
 

--- a/packages/ui/gateway.renproject.io/src/state/sdkContainer.tsx
+++ b/packages/ui/gateway.renproject.io/src/state/sdkContainer.tsx
@@ -170,6 +170,17 @@ export class SDKContainer extends Container<typeof initialState> {
             await postMessageToClient(window, this.uiContainer.state.gatewayPopupID, GatewayMessageType.Status, this.getTransferStatus(transfer));
         }
         try {
+            if (
+                JSON.stringify(this.state.transfer) !== JSON.stringify(transfer) &&
+                this.uiContainer.state.gatewayPopupID
+            ) {
+                await postMessageToClient(window, this.uiContainer.state.gatewayPopupID, GatewayMessageType.TransferUpdated, { transfer });
+            }
+        } catch (error) {
+            console.error(error);
+        }
+
+        try {
             await updateStorageTransfer(renNetwork, transfer);
         } catch (error) {
             console.error(error);


### PR DESCRIPTION
This allows integrators using GatewayJS to store all details of the trade to persistent storage as they are updated.