### PR TITLE
fix: uncaught web3 rejection

### DIFF
--- a/packages/lib/chains/chains-ethereum/src/base.ts
+++ b/packages/lib/chains/chains-ethereum/src/base.ts
@@ -104,10 +104,11 @@ export const forwardWeb3Events = <T, TEvents extends Web3Events>(
             dest.emit("eth_confirmation", confNumber, eventReceipt);
         },
     );
-    // eslint-disable-next-line no-void
-    void src.on("error", (error: Error) => {
-        dest.emit("error", error);
-    });
+    // Don't forward - instead these should be listened for and thrown.
+    // // eslint-disable-next-line no-void
+    // void src.on("error", (error: Error) => {
+    //     dest.emit("error", error);
+    // });
 };
 
 /**


### PR DESCRIPTION
"error" events from Web3 were being forwarded to the event emitter returned by .mint or .burn, in addition to being caught and thrown. This PR fixes it by removing the event forwarding for errors.