### PR TITLE
fix: bsc explorer links

### DIFF
--- a/packages/lib/chains/chains-ethereum/src/base.ts
+++ b/packages/lib/chains/chains-ethereum/src/base.ts
@@ -80,7 +80,7 @@ const resolveNetwork = (
     return networkConfig;
 };
 
-type NetworkInput =
+export type NetworkInput =
     | RenNetwork
     | RenNetworkString
     | RenNetworkDetails

--- a/packages/lib/chains/chains-ethereum/src/bsc.ts
+++ b/packages/lib/chains/chains-ethereum/src/bsc.ts
@@ -4,11 +4,13 @@ import {
     RenNetworkDetails,
     RenNetworkString,
 } from "@renproject/interfaces";
-import { Callable } from "@renproject/utils";
+import { Callable, utilsWithChainNetwork } from "@renproject/utils";
 import { provider } from "web3-providers";
+import { EthAddress, EthTransaction, NetworkInput } from "./base";
 
 import { EthereumClass } from "./ethereum";
 import { EthereumConfig } from "./networks";
+import { addressIsValid } from "./utils";
 
 export const renBscTestnet: EthereumConfig = {
     name: "BSC Testnet",
@@ -77,6 +79,30 @@ export class BinanceSmartChainClass extends EthereumClass {
     public chain = BinanceSmartChainClass.chain;
     public name = BinanceSmartChainClass.chain;
     public legacyName = undefined;
+
+    public static utils = {
+        addressIsValid,
+        addressExplorerLink: (
+            address: EthAddress,
+            network: NetworkInput = renBscMainnet,
+        ): string =>
+            `${
+                (resolveBSCNetwork(network) || renBscMainnet).etherscan
+            }/address/${address}`,
+
+        transactionExplorerLink: (
+            transaction: EthTransaction,
+            network: NetworkInput = renBscMainnet,
+        ): string =>
+            `${
+                (resolveBSCNetwork(network) || renBscMainnet).etherscan
+            }/tx/${transaction}`,
+    };
+
+    public utils = utilsWithChainNetwork(
+        BinanceSmartChainClass.utils,
+        () => this.renNetworkDetails,
+    );
 
     constructor(
         web3Provider: provider,

--- a/packages/lib/chains/chains-ethereum/test/index.spec.ts
+++ b/packages/lib/chains/chains-ethereum/test/index.spec.ts
@@ -48,7 +48,7 @@ export const findBurnByNonce = async (
 };
 
 describe("Refactor: mint", () => {
-    it.only("mint to contract", async function() {
+    it.skip("mint to contract", async function() {
         this.timeout(100000000000);
 
         const infuraURL = `${Chains.renMainnet.infura}/v3/${process.env.INFURA_KEY}`; // renBscDevnet.infura

--- a/packages/lib/chains/chains-ethereum/test/utils.spec.ts
+++ b/packages/lib/chains/chains-ethereum/test/utils.spec.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-console */
+
+import { BinanceSmartChain } from "@renproject/chains";
+
+import chai from "chai";
+chai.should();
+
+const address = "0x" + "00".repeat(20);
+const txHash = "0x" + "00".repeat(32);
+
+describe("BSC Utils", () => {
+    describe("Explorer links", () => {
+        it("Mainnet", () => {
+            const bsc = new BinanceSmartChain(null, "mainnet");
+
+            for (const obj of [BinanceSmartChain, bsc]) {
+                obj.utils
+                    .addressExplorerLink(address)
+                    .should.equal("https://bscscan.com/address/" + address);
+
+                obj.utils
+                    .transactionExplorerLink(txHash)
+                    .should.equal("https://bscscan.com/tx/" + txHash);
+            }
+        });
+
+        it("Testnet", () => {
+            const bsc = new BinanceSmartChain(null, "testnet");
+
+            bsc.utils
+                .addressExplorerLink(address)
+                .should.equal("https://testnet.bscscan.com/address/" + address);
+
+            bsc.utils
+                .transactionExplorerLink(txHash)
+                .should.equal("https://testnet.bscscan.com/tx/" + txHash);
+
+            BinanceSmartChain.utils
+                .addressExplorerLink(address, "testnet")
+                .should.equal("https://testnet.bscscan.com/address/" + address);
+
+            BinanceSmartChain.utils
+                .transactionExplorerLink(txHash, "testnet")
+                .should.equal("https://testnet.bscscan.com/tx/" + txHash);
+        });
+    });
+});


### PR DESCRIPTION
This PR updates the Binance Smart Chain's class to provide its own utils instead of inheriting from the Ethereum class.
This ensures that the right network is passed into the explorer url getters.