### PR TITLE
fix(ren-tx): resolve timing issue when burning

### DIFF
--- a/packages/lib/ren-tx/test/machines.spec.ts
+++ b/packages/lib/ren-tx/test/machines.spec.ts
@@ -88,6 +88,7 @@ const depositModel = createModel(
             },
         } as any),
 ).withEvents({
+    CHECK: {},
     DETECTED: {},
     RESTORE: {},
     ERROR: {
@@ -140,6 +141,7 @@ const burnModel = createModel(
     } as any),
 ).withEvents({
     RESTORE: {},
+    CREATED: {},
     "done.invoke.burnCreator": {
         exec: async () => {},
         cases: [{ data: { ...makeTestContext().tx, transactions: {} } }],


### PR DESCRIPTION
Currently, there is a period of time where the burn machine is setting up the `burnAndRelease.burn` instance, where `SUBMIT` events will be ignored.

This introduces a new state `creating` in the burn machine that represents the period before "SUBMIT" events can be handled. UIs should no provide the ability to send this event during this state (see the state chart for valid states where it can be sent)

It also fixes progression until the release stage in the burn machine (would previously be stuck on confirming) and restoring completed burn + mint txs in the 0.3 networks 