### PR TITLE
fix(ren-tx): correct txhashes & handle incorrect gateway address

### DIFF
--- a/packages/lib/ren-tx/src/machines/burn.ts
+++ b/packages/lib/ren-tx/src/machines/burn.ts
@@ -105,12 +105,17 @@ export interface BurnMachineSchema {
          * can be submitted to renVM for release */
         srcConfirmed: {};
 
+        /** RenVM has recieved the tx and provided a hash */
+        // accepted: {};
+
         /** An error occored while processing the release
          * Should only come from renVM */
         errorReleasing: {};
 
         /** The release tx has successfully been broadcast
-         * We only care if the txHash has been issued by renVM */
+         * For network v0.3 we get the release destTxHash
+         * otherwise it will never be provided
+         */
         destInitiated: {};
     };
 }
@@ -341,6 +346,7 @@ export const burnMachine = Machine<
                     },
                 },
             },
+
             errorReleasing: {
                 meta: {
                     test: (_: void, state: any) => {
@@ -382,6 +388,11 @@ export const burnMachine = Machine<
                 },
             },
 
+            // FIXME: not currently used, but should be tracked once migrated to 0.3
+            // accepted: {
+            //     meta: { test: async () => {} },
+            //},
+
             destInitiated: {
                 meta: { test: async () => {} },
             },
@@ -397,7 +408,11 @@ export const burnMachine = Machine<
                 getFirstTx(ctx.tx)?.sourceTxConfs >=
                 (getFirstTx(ctx.tx)?.sourceTxConfTarget ||
                     Number.POSITIVE_INFINITY),
-            isDestInitiated: (ctx, _evt) => !!getFirstTx(ctx.tx)?.destTxHash,
+            // We assume that the renVmHash implies that the dest tx has been initiated
+            isDestInitiated: (ctx, _evt) => !!getFirstTx(ctx.tx)?.renVMHash,
+            // FIXME: once we have migrated to 0.3 for all assets, actually check for
+            // destTxHash
+            // isDestInitiated: (ctx, _evt) => !!getFirstTx(ctx.tx)?.destTxHash,
         },
     },
 );

--- a/packages/lib/ren-tx/src/machines/deposit.ts
+++ b/packages/lib/ren-tx/src/machines/deposit.ts
@@ -318,6 +318,7 @@ export const depositMachine = Machine<
                     },
                 },
             },
+
             accepted: {
                 entry: sendParent((ctx, _) => {
                     return {
@@ -339,6 +340,7 @@ export const depositMachine = Machine<
                 },
                 meta: { test: async () => {} },
             },
+
             errorSubmitting: {
                 entry: sendParent((ctx, _) => {
                     return {
@@ -367,6 +369,7 @@ export const depositMachine = Machine<
                     },
                 },
             },
+
             claiming: {
                 entry: send(
                     (ctx) => ({
@@ -416,12 +419,14 @@ export const depositMachine = Machine<
                 },
                 meta: { test: async () => {} },
             },
+
             destInitiated: {
                 on: {
                     ACKNOWLEDGE: "completed",
                 },
                 meta: { test: async () => {} },
             },
+
             rejected: {
                 meta: { test: async () => {} },
             },
@@ -434,6 +439,7 @@ export const depositMachine = Machine<
             },
         },
     },
+
     {
         guards: {
             isSrcSettling: ({

--- a/packages/lib/ren-tx/src/types/transaction.ts
+++ b/packages/lib/ren-tx/src/types/transaction.ts
@@ -28,6 +28,8 @@ export interface GatewayTransaction {
      * How many confirmations needed to consider the source tx accepted
      */
     sourceTxConfTarget?: number;
+    /* Hash of renVM transaction */
+    renVMHash?: string;
     /**
      * Response to renvm signing request
      */
@@ -42,6 +44,12 @@ export interface GatewayTransaction {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rawSourceTx: DepositCommon<any>;
+
+    /**
+     * Underlying dest chain tx
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawDestTx?: any;
     /**
      * Additional parameters for constructing a custom transaction
      * Provided at the point of submission

--- a/packages/lib/ren-tx/test/mint.spec.ts
+++ b/packages/lib/ren-tx/test/mint.spec.ts
@@ -35,7 +35,7 @@ const makeMintTransaction = (): GatewaySession => ({
     customParams: {},
 });
 
-jest.setTimeout(1000 * 106);
+jest.setTimeout(1000 * 56);
 describe("MintMachine", () => {
     it("should create a tx", async () => {
         const fromChainMap = {
@@ -58,9 +58,12 @@ describe("MintMachine", () => {
             toChainMap,
         });
 
-        const p: Promise<string> = new Promise((resolve) => {
+        const p: Promise<string> = new Promise((resolve, reject) => {
             const service = interpret(machine)
                 .onTransition((state) => {
+                    if (state.context.tx.error) {
+                        reject(state.context.tx.error);
+                    }
                     if (state?.context?.tx?.gatewayAddress) {
                         // we have successfully detected a deposit and spawned
                         // a machine to listen for updates
@@ -106,9 +109,12 @@ describe("MintMachine", () => {
         }, 100);
 
         let prevDepositTx: GatewayTransaction;
-        const p = new Promise((resolve) => {
+        const p = new Promise((resolve, reject) => {
             const service = interpret(machine)
                 .onTransition((state) => {
+                    if (state.context.tx.error) {
+                        reject(state.context.tx.error);
+                    }
                     const depositTx = Object.values(
                         state.context.tx.transactions,
                     )[0];
@@ -195,10 +201,13 @@ describe("MintMachine", () => {
             setConfirmations((confirmations += 1));
         }, 10000);
 
-        const p = new Promise((resolve) => {
+        const p = new Promise((resolve, reject) => {
             let subscribed = false;
             const service = interpret(machine)
                 .onTransition((state) => {
+                    if (state.context.tx.error) {
+                        reject(state.context.tx.error);
+                    }
                     const depositMachine = Object.values(
                         state.context?.depositMachines || {},
                     )[0];
@@ -285,13 +294,13 @@ describe("MintMachine", () => {
                 ...makeMintTransaction(),
                 nonce:
                     "82097a6ec9591b770b8a2db129e067602e842c3d3a088cfc67770e7e2312af93",
-                gatewayAddress: "gatewayaddr",
+                gatewayAddress: "gatewayAddress",
                 transactions: {
-                    ["krNFdjFVrEdF2Ob+AxVI6+sB6sEQxvfVt5u7e04WYEE="]: {
+                    ["0xb5252f4b08fda457234a6da6fd77c3b23adf8b3f4e020615b876b28aa7ee6299"]: {
                         sourceTxAmount: 1,
                         sourceTxConfs: 0,
                         sourceTxHash:
-                            "krNFdjFVrEdF2Ob+AxVI6+sB6sEQxvfVt5u7e04WYEE=",
+                            "0xb5252f4b08fda457234a6da6fd77c3b23adf8b3f4e020615b876b28aa7ee6299",
                         rawSourceTx: { amount: "1", transaction: {} },
                     },
                 },
@@ -307,10 +316,13 @@ describe("MintMachine", () => {
             setConfirmations((confirmations += 1));
         }, 10000);
 
-        const p = new Promise((resolve) => {
+        const p = new Promise((resolve, reject) => {
             let subscribed = false;
             const service = interpret(machine)
                 .onTransition((state) => {
+                    if (state.context.tx.error) {
+                        reject(state.context.tx.error);
+                    }
                     const depositMachine = Object.values(
                         state.context?.depositMachines || {},
                     )[0];
@@ -397,11 +409,11 @@ describe("MintMachine", () => {
                     "82097a6ec9591b770b8a2db129e067602e842c3d3a088cfc67770e7e2312af93",
                 gatewayAddress: "gatewayAddress",
                 transactions: {
-                    ["krNFdjFVrEdF2Ob+AxVI6+sB6sEQxvfVt5u7e04WYEE="]: {
+                    ["0xb5252f4b08fda457234a6da6fd77c3b23adf8b3f4e020615b876b28aa7ee6299"]: {
                         sourceTxAmount: 1,
                         sourceTxConfs: 1,
                         sourceTxHash:
-                            "krNFdjFVrEdF2Ob+AxVI6+sB6sEQxvfVt5u7e04WYEE=",
+                            "0xb5252f4b08fda457234a6da6fd77c3b23adf8b3f4e020615b876b28aa7ee6299",
                         rawSourceTx: { amount: "1", transaction: {} },
                     },
                 },
@@ -417,10 +429,13 @@ describe("MintMachine", () => {
             setConfirmations((confirmations += 1));
         }, 10000);
 
-        const p = new Promise((resolve) => {
+        const p = new Promise((resolve, reject) => {
             let subscribed = false;
             const service = interpret(machine)
                 .onTransition((state) => {
+                    if (state.context.tx.error) {
+                        reject(state.context.tx.error);
+                    }
                     const depositMachine = Object.values(
                         state.context?.depositMachines || {},
                     )[0];

--- a/packages/lib/ren-tx/test/testutils/mock.ts
+++ b/packages/lib/ren-tx/test/testutils/mock.ts
@@ -36,7 +36,7 @@ export const buildMockLockChain = (conf = { targetConfirmations: 500 }) => {
                 amount: "1",
             });
         },
-        getGatewayAddress: () => "gatGatewayAddress",
+        getGatewayAddress: () => "gatewayAddress",
         getPubKeyScript: () => Buffer.from("pubkey"),
         depositV1HashString: () => "v1HashString",
         legacyName: "Btc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6106,9 +6106,9 @@ bitcore-lib@^8.22.2, bitcore-lib@^8.23.1:
     inherits "=2.0.1"
     lodash "^4.17.20"
 
-"bitgo-utxo-lib@git+https://github.com/ren-forks/bitgo-utxo-lib.git#b848585e65b42c48b98c207e72d7d3006c9a5da0":
+"bitgo-utxo-lib@https://github.com/ren-forks/bitgo-utxo-lib#b848585e65b42c48b98c207e72d7d3006c9a5da0":
   version "1.9.1"
-  resolved "git+https://github.com/ren-forks/bitgo-utxo-lib.git#b848585e65b42c48b98c207e72d7d3006c9a5da0"
+  resolved "https://github.com/ren-forks/bitgo-utxo-lib#b848585e65b42c48b98c207e72d7d3006c9a5da0"
   dependencies:
     bech32 "0.0.3"
     bigi "^1.4.0"


### PR DESCRIPTION
Previously, we incorrectly used renVM hashes for sourceTxHash when minting,
and destTxHash when burning. This PR adds a new field to track the renVMHash
separately, and provides the correct hashes when possible.

Note, the destTxHash is only available for network 0.3 txs when burning, so 
we currently assume that the burn tx is complete once we receive a renVMHash,
and provide an optional destTxHash for 0.3 txes.

This PR also fixes a newly discovered issue where an incorrect gateway address
provided when creating a mintMachine would never detect txs; we will enter the
"errorInitializing" state now.