### PR TITLE
feat(ren tx): single ren js instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "tsdx": "^0.14.0",
         "typedoc": "^0.19.1",
         "typedoc-plugin-no-inherit": "^1.2.0",
-        "typescript": "4.0.5",
+        "typescript": "4.1.3",
         "webpack": "4.42.0",
         "webpack-cli": "^3.3.12",
         "webpack-node-externals": "^2.5.2"

--- a/packages/lib/ren-tx/package.json
+++ b/packages/lib/ren-tx/package.json
@@ -49,10 +49,10 @@
         "@renproject/ren": "^2.0.7",
         "@renproject/rpc": "^2.0.7",
         "dotenv": "^8.2.0",
-        "xstate": "^4.13.0"
+        "xstate": "^4.16.0"
     },
     "peerDependencies": {
-        "@renproject/ren": "^2.0.0-alpha.8",
-        "xstate": "^4.13.0"
+        "@renproject/ren": "^2.0.7",
+        "xstate": "^4.16.0"
     }
 }

--- a/packages/lib/ren-tx/src/configs/genericBurn.ts
+++ b/packages/lib/ren-tx/src/configs/genericBurn.ts
@@ -2,7 +2,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO: Improve typings.
 
-import { BurnAndReleaseStatus } from "@renproject/ren/build/main/burnAndRelease";
+import { DepositCommon } from "@renproject/interfaces";
+import {
+    BurnAndRelease,
+    BurnAndReleaseStatus,
+} from "@renproject/ren/build/main/burnAndRelease";
 import BigNumber from "bignumber.js";
 import { Actor, assign, MachineOptions, Receiver, Sender, spawn } from "xstate";
 
@@ -96,6 +100,142 @@ const spawnBurnTransaction = assign<BurnMachineContext, BurnMachineEvent>({
     },
 });
 
+const performBurn = async (
+    burn: BurnAndRelease<any, DepositCommon<any>, any, any>,
+    callback: Sender<BurnMachineEvent>,
+    cleaners: Array<() => void>,
+    tx: GatewayTransaction,
+) => {
+    // will resume from previous tx if we have the hash
+    const burnRef = burn.burn();
+
+    const burnListener = (confs: number) => {
+        if (confs >= (tx.sourceTxConfTarget || 6)) {
+            // stop listening for confirmations once confirmed
+            burnRef.removeListener("confirmation", burnListener);
+
+            callback({
+                type: "CONFIRMED",
+                data: { ...tx, sourceTxConfs: confs },
+            });
+        } else {
+            callback({
+                type: "CONFIRMATION",
+                // FIXME: get proper confirmation target for burning somewhere
+                data: {
+                    ...tx,
+                    sourceTxConfs: confs,
+                    sourceTxConfTarget: tx.sourceTxConfTarget || 6,
+                },
+            });
+        }
+    };
+
+    cleaners.push(() => {
+        burnRef._cancel();
+        burnRef.removeListener("confirmation", burnListener);
+    });
+
+    try {
+        const r = await burnRef
+            // host chain tx hash
+            .on("transactionHash", (txHash: string) => {
+                tx.sourceTxHash = txHash;
+                tx.sourceTxConfs = 0;
+                callback({
+                    type: "SUBMITTED",
+                    data: {
+                        ...tx,
+                    },
+                });
+            })
+            .on("confirmation", burnListener);
+
+        if (tx) {
+            // the burn status is canonical, we should proceed if
+            // it says we have burned
+            if (r.status == BurnAndReleaseStatus.Burned) {
+                // FIXME: ensure that the confs always match
+                // the target
+                tx.sourceTxConfs = 7;
+            }
+
+            // Always call because we won't get an emission
+            // if the burn is already done
+            burnListener(tx.sourceTxConfs);
+        }
+    } catch (error) {
+        throw error;
+    }
+};
+
+const performRelease = async (
+    burn: BurnAndRelease<any, DepositCommon<any>, any, any>,
+    callback: Sender<BurnMachineEvent>,
+    cleaners: Array<() => void>,
+    tx: GatewayTransaction,
+) => {
+    // Only start processing release once confirmed
+    // Release from renvm status
+    const releaseListener = (status: string) => {
+        status === "confirming"
+            ? console.debug(`confirming`)
+            : console.debug("status", status);
+    };
+
+    // renvm hash status
+    const hashListener = (hash: string) => {
+        callback({
+            type: "ACCEPTED",
+            data: { ...tx, renVMHash: hash },
+        });
+    };
+
+    const transactionListener = (transaction: any) => {
+        callback({
+            type: "RELEASED",
+            data: {
+                ...tx,
+                destTxHash: transaction.hash,
+                // Can be used to construct blockchain explorer link
+                rawDestTx: transaction,
+            },
+        });
+    };
+
+    const releaseRef = burn.release();
+    cleaners.push(() => {
+        releaseRef._cancel();
+        releaseRef.removeListener("status", releaseListener);
+        releaseRef.removeListener("transaction", transactionListener);
+        releaseRef.removeListener("txHash", hashListener);
+    });
+
+    releaseRef.catch((e) => {
+        console.error("release error", e);
+        callback({
+            type: "RELEASE_ERROR",
+            data: e.toString(),
+        });
+    });
+
+    try {
+        const res = await releaseRef
+            .on("status", releaseListener)
+            .on("transaction", transactionListener)
+            .on("txHash", hashListener);
+        callback({
+            type: "RELEASED",
+            data: { ...tx, renResponse: res },
+        });
+    } catch (e) {
+        callback({
+            type: "RELEASE_ERROR",
+            data: e.toString(),
+        });
+    }
+};
+
 const burnTransactionListener = (context: BurnMachineContext) => (
     callback: Sender<BurnMachineEvent>,
     receive: Receiver<any>,
@@ -114,88 +254,23 @@ const burnTransactionListener = (context: BurnMachineContext) => (
                 setTimeout(() => callback("SUBMIT"), 500);
             }
 
-            let tx: GatewayTransaction = Object.values(
-                context.tx.transactions,
-            )[0];
+            const tx: GatewayTransaction =
+                Object.values(context.tx.transactions)[0] || {};
 
-            const performBurn = async () => {
-                // Only allow burn to be called once
-                if (burning) return;
-                burning = true;
-                // will resume from previous tx if we have the hash
-                const burnRef = burn.burn();
-
-                const burnListener = async (confs: number) => {
-                    if (confs >= (tx.sourceTxConfTarget || 6)) {
-                        // stop listening for confirmations once confirmed
-                        burnRef.removeListener("confirmation", burnListener);
-
-                        callback({
-                            type: "CONFIRMED",
-                            data: { ...tx, sourceTxConfs: confs },
-                        });
-                    } else {
-                        callback({
-                            type: "CONFIRMATION",
-                            // FIXME: get proper confirmation target for burning somewhere
-                            data: {
-                                ...tx,
-                                sourceTxConfs: confs,
-                                sourceTxConfTarget: tx.sourceTxConfTarget || 6,
-                            },
-                        });
-                    }
-                };
-
-                cleaners.push(() => {
-                    burnRef._cancel();
-                    burnRef.removeListener("confirmation", burnListener);
-                });
-
-                try {
-                    const r = await burnRef
-                        // host chain tx hash
-                        .on("transactionHash", (txHash: string) => {
-                            tx = {
-                                sourceTxHash: txHash,
-                                sourceTxConfs: 0,
-                                sourceTxAmount: Number(
-                                    context.tx.suggestedAmount,
-                                ),
-                                rawSourceTx: {
-                                    amount: String(context.tx.suggestedAmount),
-                                    transaction: {},
-                                },
-                            };
-                            callback({
-                                type: "SUBMITTED",
-                                data: {
-                                    ...tx,
-                                },
-                            });
-                        })
-                        .on("confirmation", burnListener);
-                    if (tx) {
-                        // the burn status is canonical, we should proceed if
-                        // it says we have burned
-                        if (r.status == BurnAndReleaseStatus.Burned) {
-                            // FIXME: ensure that the confs always match
-                            // the target
-                            tx.sourceTxConfs = 7;
-                        }
-
-                        // Always call because we won't get an emission
-                        // if the burn is already done
-                        burnListener(tx.sourceTxConfs);
-                    }
-                } catch (error) {
-                    throw error;
-                }
+            tx.sourceTxAmount = Number(context.tx.suggestedAmount);
+            tx.rawSourceTx = {
+                amount: String(context.tx.suggestedAmount),
+                transaction: {},
             };
 
-            receive(async (event: BurnMachineEvent) => {
+            receive((event: BurnMachineEvent) => {
                 if (event.type === "SUBMIT") {
-                    performBurn()
+                    // Only burn once
+                    if (burning) {
+                        return;
+                    }
+                    burning = true;
+                    performBurn(burn, callback, cleaners, tx)
                         .then()
                         .catch((e) => {
                             console.error(e);
@@ -205,69 +280,17 @@ const burnTransactionListener = (context: BurnMachineContext) => (
                             });
                         });
                 }
+
                 if (event.type === "RELEASE") {
-                    // Only start processing release once confirmed
-                    // Release from renvm status
-                    const releaseListener = (status: string) => {
-                        status === "confirming"
-                            ? console.debug(`confirming`)
-                            : console.debug("status", status);
-                    };
-
-                    // renvm hash status
-                    const hashListener = (hash: string) => {
-                        callback({
-                            type: "ACCEPTED",
-                            data: { ...tx, renVMHash: hash },
+                    performRelease(burn, callback, cleaners, tx)
+                        .then()
+                        .catch((e) => {
+                            console.error(e);
+                            callback({
+                                type: "BURN_ERROR",
+                                data: e.toString(),
+                            });
                         });
-                    };
-
-                    const transactionListener = (transaction: any) => {
-                        callback({
-                            type: "RELEASED",
-                            data: {
-                                ...tx,
-                                destTxHash: transaction.hash,
-                                // Can be used to construct blockchain explorer link
-                                rawDestTx: transaction,
-                            },
-                        });
-                    };
-
-                    const releaseRef = burn.release();
-                    cleaners.push(() => {
-                        releaseRef._cancel();
-                        releaseRef.removeListener("status", releaseListener);
-                        releaseRef.removeListener(
-                            "transaction",
-                            transactionListener,
-                        );
-                        releaseRef.removeListener("txHash", hashListener);
-                    });
-
-                    releaseRef.catch((e) => {
-                        console.error("release error", e.toString());
-                        callback({
-                            type: "RELEASE_ERROR",
-                            data: e.toString(),
-                        });
-                    });
-
-                    try {
-                        const res = await releaseRef
-                            .on("status", releaseListener)
-                            .on("transaction", transactionListener)
-                            .on("txHash", hashListener);
-                        callback({
-                            type: "RELEASED",
-                            data: { ...tx, renResponse: res },
-                        });
-                    } catch (e) {
-                        callback({
-                            type: "RELEASE_ERROR",
-                            data: e.toString(),
-                        });
-                    }
                 }
             });
         })

--- a/packages/lib/ren-tx/src/configs/genericMint.ts
+++ b/packages/lib/ren-tx/src/configs/genericMint.ts
@@ -2,13 +2,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO: Improve typings.
 
+import { DepositCommon } from "@renproject/interfaces";
 import RenJS from "@renproject/ren";
-import { LockAndMintDeposit } from "@renproject/ren/build/main/lockAndMint";
+import {
+    LockAndMint,
+    LockAndMintDeposit,
+} from "@renproject/ren/build/main/lockAndMint";
 import BigNumber from "bignumber.js";
-import { Actor, assign, MachineOptions, Receiver, Sender, spawn } from "xstate";
+import {
+    Actor,
+    assign,
+    MachineOptions,
+    Receiver,
+    Sender,
+    spawn,
+    send,
+    actions,
+} from "xstate";
 
 import { depositMachine, DepositMachineContext } from "../machines/deposit";
-import { GatewayMachineContext } from "../machines/mint";
+import { GatewayMachineContext, GatewayMachineEvent } from "../machines/mint";
 import { GatewaySession, GatewayTransaction } from "../types/transaction";
 
 /*
@@ -113,224 +126,257 @@ const txCreator = async (context: GatewayMachineContext) => {
     return newTx;
 };
 
+const initMinter = async (
+    context: GatewayMachineContext,
+    callback: Sender<GatewayMachineEvent>,
+) => {
+    const minter = await renLockAndMint(context);
+
+    if (minter.gatewayAddress != context.tx.gatewayAddress) {
+        callback({
+            type: "ERROR_LISTENING",
+            data: new Error(
+                `Incorrect gateway address ${minter.gatewayAddress} != ${context.tx.gatewayAddress}`,
+            ),
+        });
+    }
+    return minter;
+};
+
+const handleSettle = async (
+    sourceTxHash: string,
+    deposit: LockAndMintDeposit,
+    callback: Sender<any>,
+) => {
+    try {
+        await deposit
+            .confirmed()
+            .on("target", (confs, targetConfs) => {
+                const confirmedTx = {
+                    sourceTxHash,
+                    sourceTxConfs: confs,
+                    sourceTxConfTarget: targetConfs,
+                };
+                callback({
+                    type: "CONFIRMATION",
+                    data: confirmedTx,
+                });
+            })
+            .on("confirmation", (confs, targetConfs) => {
+                const confirmedTx = {
+                    sourceTxHash,
+                    sourceTxConfs: confs,
+                    sourceTxConfTarget: targetConfs,
+                };
+                callback({
+                    type: "CONFIRMATION",
+                    data: confirmedTx,
+                });
+            });
+        callback({
+            type: "CONFIRMED",
+            data: {
+                sourceTxHash,
+            },
+        });
+    } catch (e) {
+        callback({
+            type: "ERROR",
+            data: {
+                sourceTxHash,
+            },
+            error: e,
+        });
+        console.error(e);
+    }
+};
+
+const handleSign = async (
+    sourceTxHash: string,
+    deposit: LockAndMintDeposit,
+    callback: Sender<any>,
+) => {
+    try {
+        const v = await deposit
+            .signed()
+            .on("status", (state) => console.log(state));
+
+        if (!v._state.queryTxResult || !v._state.queryTxResult.out) {
+            console.error("missing response data", v._state.queryTxResult);
+            callback({
+                type: "SIGN_ERROR",
+                data: {
+                    sourceTxHash,
+                },
+                error: new Error("No signature!").toString(),
+            });
+            return;
+        }
+        if (
+            v._state.queryTxResult.out &&
+            v._state.queryTxResult.out.revert !== undefined
+        ) {
+            callback({
+                type: "SIGN_ERROR",
+                data: {
+                    sourceTxHash,
+                },
+                error: v._state.queryTxResult.out.revert.toString(),
+            });
+            return;
+        } else {
+            callback({
+                type: "SIGNED",
+                data: {
+                    sourceTxHash,
+                    renResponse: hexify(v._state.queryTxResult.out),
+                    signature: v._state.queryTxResult.out.signature?.toString(
+                        "hex",
+                    ),
+                },
+            });
+        }
+    } catch (e) {
+        console.error("Sign error!", e);
+        // If a tx has already been minted, we will get an error at this step
+        // We can assume that a "utxo spent" error implies that the asset has been minted
+        callback({
+            type: "SIGN_ERROR",
+            data: {
+                sourceTxHash,
+            },
+            error: e,
+        });
+    }
+};
+
+const handleMint = async (
+    sourceTxHash: string,
+    deposit: LockAndMintDeposit,
+    callback: Sender<any>,
+) => {
+    await deposit
+        .mint()
+        .on("transactionHash", (transactionHash) => {
+            const submittedTx = {
+                sourceTxHash,
+                destTxHash: transactionHash,
+            };
+            callback({
+                type: "SUBMITTED",
+                data: submittedTx,
+            });
+        })
+        .catch((e) => {
+            callback({
+                type: "SUBMIT_ERROR",
+                data: { sourceTxHash },
+                error: e,
+            });
+            console.error("Submit error!", e);
+        });
+};
+
+const mintFlow = async (
+    context: GatewayMachineContext,
+    callback: Sender<GatewayMachineEvent>,
+    receive: Receiver<any>,
+    minter: LockAndMint<any, DepositCommon<any>, any, any, any>,
+) => {
+    const deposits = new Map<string, LockAndMintDeposit>();
+
+    const depositHandler = (deposit: LockAndMintDeposit) => {
+        const txHash = deposit.params.from.transactionID(
+            deposit.depositDetails.transaction,
+        );
+
+        //        const trackedDeposit = deposits.get(txHash);
+
+        deposits.set(txHash, deposit);
+
+        const persistedTx = context.tx.transactions[txHash];
+
+        const rawSourceTx = deposit.depositDetails;
+        const depositState: GatewayTransaction = persistedTx || {
+            sourceTxHash: txHash,
+            renVMHash: deposit.txHash(),
+            sourceTxAmount: parseInt(rawSourceTx.amount),
+            sourceTxConfs: 0,
+            rawSourceTx,
+        };
+
+        if (!persistedTx) {
+            callback({
+                type: "DEPOSIT",
+                data: { ...depositState },
+            });
+        }
+        callback({ type: "RESTORED", data: depositState });
+    };
+
+    minter.on("deposit", depositHandler);
+
+    receive((event) => {
+        const deposit = deposits.get(event.hash);
+        if (!deposit) {
+            // Theoretically this should never happen
+            throw new Error("missing deposit!: " + event.hash);
+        }
+
+        switch (event.type) {
+            case "SETTLE":
+                handleSettle(event.hash, deposit, callback);
+                break;
+            case "SIGN":
+                handleSign(event.hash, deposit, callback);
+                break;
+            case "MINT":
+                handleMint(event.hash, deposit, callback);
+                break;
+        }
+    });
+
+    receive((event) => {
+        switch (event.type) {
+            case "RESTORE":
+                minter
+                    .processDeposit(event.data.rawSourceTx)
+                    .then((r) => {
+                        // Previously the on('deposit') event would have fired when restoring
+                        // Now, we use the promise result to set up the handler as well in
+                        // case the `deposit` event does not fire
+                        depositHandler(r);
+                    })
+                    .catch((e) => {
+                        callback({
+                            type: "ERROR",
+                            data: event.data,
+                            error: e,
+                        });
+                        console.error(e);
+                    });
+                break;
+        }
+    });
+};
+
 // Listen for confirmations on the source chain
-const depositListener = (
-    context: GatewayMachineContext | DepositMachineContext,
-) => (callback: Sender<any>, receive: Receiver<any>) => {
+const depositListener = (context: GatewayMachineContext) => (
+    callback: Sender<any>,
+    receive: Receiver<any>,
+) => {
     let cleanup = () => {};
 
-    const targetDeposit = (context as DepositMachineContext).deposit;
-    let listening = false;
-
-    renLockAndMint(context)
+    initMinter(context, callback)
         .then((minter) => {
             cleanup = () => minter.removeAllListeners();
-            if (minter.gatewayAddress != context.tx.gatewayAddress) {
-                callback({
-                    type: "ERROR_LISTENING",
-                    data: new Error(
-                        `Incorrect gateway address ${minter.gatewayAddress} != ${context.tx.gatewayAddress}`,
-                    ),
-                });
-                return;
-            }
-
-            const depositListener = (deposit: LockAndMintDeposit) => {
-                // Don't register listeners multiple times
-                if (targetDeposit && listening) return;
-                listening = true;
-
-                // Register event handlers prior to setup in case events land early
-                // If we don't have a targetDeposit, we won't handle events
-                targetDeposit &&
-                    receive((event) => {
-                        switch (event.type) {
-                            case "SETTLE":
-                                deposit
-                                    .confirmed()
-                                    .on("target", (confs, targetConfs) => {
-                                        const confirmedTx = {
-                                            sourceTxConfs: confs,
-                                            sourceTxConfTarget: targetConfs,
-                                        };
-                                        callback({
-                                            type: "CONFIRMATION",
-                                            data: confirmedTx,
-                                        });
-                                    })
-                                    .on(
-                                        "confirmation",
-                                        (confs, targetConfs) => {
-                                            const confirmedTx = {
-                                                sourceTxConfs: confs,
-                                                sourceTxConfTarget: targetConfs,
-                                            };
-                                            callback({
-                                                type: "CONFIRMATION",
-                                                data: confirmedTx,
-                                            });
-                                        },
-                                    )
-                                    .then(() => {
-                                        callback({
-                                            type: "CONFIRMED",
-                                        });
-                                    })
-                                    .catch((e) => {
-                                        callback({ type: "ERROR", error: e });
-                                        console.error(e);
-                                    });
-                                break;
-
-                            case "SIGN":
-                                deposit
-                                    .signed()
-                                    .on("status", (state) => console.log(state))
-                                    .then((v) => {
-                                        if (
-                                            !v._state.queryTxResult ||
-                                            !v._state.queryTxResult.out
-                                        ) {
-                                            console.error(
-                                                "missing response data",
-                                                v._state.queryTxResult,
-                                            );
-                                            callback({
-                                                type: "SIGN_ERROR",
-                                                data: new Error(
-                                                    "No signature!",
-                                                ),
-                                            });
-                                            return;
-                                        }
-                                        if (
-                                            v._state.queryTxResult.out &&
-                                            v._state.queryTxResult.out
-                                                .revert !== undefined
-                                        ) {
-                                            callback({
-                                                type: "SIGN_ERROR",
-                                                data: new Error(
-                                                    v._state.queryTxResult.out.revert.toString(),
-                                                ),
-                                            });
-                                            return;
-                                        } else {
-                                            callback({
-                                                type: "SIGNED",
-                                                data: {
-                                                    renResponse: hexify(
-                                                        v._state.queryTxResult
-                                                            .out,
-                                                    ),
-                                                    signature: v._state.queryTxResult.out.signature?.toString(
-                                                        "hex",
-                                                    ),
-                                                },
-                                            });
-                                        }
-                                    })
-                                    .catch((e) => {
-                                        console.error("Sign error!", e);
-                                        // If a tx has already been minted, we will get an error at this step
-                                        // We can assume that a "utxo spent" error implies that the asset has been minted
-                                        callback({
-                                            type: "SIGN_ERROR",
-                                            data: e,
-                                        });
-                                    });
-                                break;
-
-                            case "MINT":
-                                deposit
-                                    .mint()
-                                    .on(
-                                        "transactionHash",
-                                        (transactionHash) => {
-                                            const submittedTx = {
-                                                destTxHash: transactionHash,
-                                            };
-                                            callback({
-                                                type: "SUBMITTED",
-                                                data: submittedTx,
-                                            });
-                                        },
-                                    )
-                                    .catch((e) => {
-                                        callback({
-                                            type: "SUBMIT_ERROR",
-                                            data: e,
-                                        });
-                                        console.error("Submit error!", e);
-                                    });
-                                break;
-                        }
-                    });
-
-                const txHash = deposit.params.from.transactionID(
-                    deposit.depositDetails.transaction,
-                );
-                const persistedTx = context.tx.transactions[txHash];
-
-                // Prevent deposit machine tx listeners from interacting with other deposits
-                if (targetDeposit) {
-                    if (targetDeposit.sourceTxHash !== txHash) {
-                        console.debug(
-                            "wrong deposit:",
-                            targetDeposit.sourceTxHash,
-                            txHash,
-                        );
-                        return;
-                    }
-                }
-
-                // If we don't have a sourceTxHash, we haven't seen a deposit yet
-                const rawSourceTx = deposit.depositDetails;
-                const depositState: GatewayTransaction = persistedTx || {
-                    sourceTxHash: txHash,
-                    renVMHash: deposit.txHash(),
-                    sourceTxAmount: parseInt(rawSourceTx.amount),
-                    sourceTxConfs: 0,
-                    rawSourceTx,
-                };
-
-                if (!persistedTx) {
-                    callback({
-                        type: "DEPOSIT",
-                        data: { ...depositState },
-                    });
-                } else {
-                    callback("DETECTED");
-                }
-            };
-
-            minter.on("deposit", depositListener);
-
-            receive((event) => {
-                switch (event.type) {
-                    case "RESTORE":
-                        minter
-                            .processDeposit(event.data)
-                            .then((r) => {
-                                // Previously the on('deposit') event would have fired when restoring
-                                // Now, we use the promise result to set up the handler as well in
-                                // case the `deposit` event does not fire
-                                depositListener(r);
-                            })
-                            .catch((e) => {
-                                callback({ type: "ERROR", error: e });
-                                console.error(e);
-                            });
-                        break;
-                }
-            });
-
-            callback("LISTENING");
+            mintFlow(context, callback, receive, minter);
         })
         .catch((e) => {
             callback({ type: "ERROR", error: e });
             console.error(e);
         });
+
     return () => {
         cleanup();
     };
@@ -339,16 +385,9 @@ const depositListener = (
 // Spawn an actor that will listen for either all deposits to a gatewayAddress,
 // or to a single deposit if present in the context
 const listenerAction = assign<GatewayMachineContext>({
-    depositListenerRef: (
-        c: GatewayMachineContext | DepositMachineContext,
-        _e: any,
-    ) => {
+    depositListenerRef: (c: GatewayMachineContext, _e: any) => {
         let actorName = `${c.tx.id}SessionListener`;
-        const deposit = (c as DepositMachineContext).deposit;
-        if (deposit) {
-            actorName = `${deposit.sourceTxHash}DepositListener`;
-        }
-        if (c.depositListenerRef && !deposit) {
+        if (c.depositListenerRef) {
             console.warn("listener already exists");
             return c.depositListenerRef;
         }
@@ -380,6 +419,36 @@ export const mintConfig: Partial<MachineOptions<GatewayMachineContext, any>> = {
         depositListener,
     },
     actions: {
+        broadcast: actions.pure((ctx, event) => {
+            return Object.values(ctx.depositMachines || {}).map((m) =>
+                send(event, { to: m.id }),
+            );
+        }),
+
+        forwardEvent: send(
+            (_, b) => {
+                return b;
+            },
+            {
+                to: (_ctx: GatewayMachineContext) => "depositListener",
+            },
+        ),
+
+        routeEvent: send(
+            (_, b) => {
+                return b;
+            },
+            {
+                to: (
+                    ctx: GatewayMachineContext,
+                    evt: { type: string; data: { sourceTxHash: string } },
+                ) => {
+                    const machines = ctx.depositMachines || {};
+                    return machines[evt.data.sourceTxHash]?.id || "missing";
+                },
+            },
+        ),
+
         spawnDepositMachine: assign({
             depositMachines: (context, evt) => {
                 const machines = context.depositMachines || {};
@@ -395,11 +464,12 @@ export const mintConfig: Partial<MachineOptions<GatewayMachineContext, any>> = {
                 delete (machineContext as any).depositMachines;
                 machines[evt.data.sourceTxHash] = spawnDepositMachine(
                     machineContext,
-                    `${String(evt.data.sourceTxHash)}DepositMachine`,
+                    `${String(evt.data.sourceTxHash)}`,
                 );
                 return machines;
             },
         }),
+
         depositMachineSpawner: assign({
             depositMachines: (context, _) => {
                 const machines = context.depositMachines || {};
@@ -415,7 +485,7 @@ export const mintConfig: Partial<MachineOptions<GatewayMachineContext, any>> = {
                     delete (machineContext as any).depositMachines;
                     machines[tx[0]] = spawnDepositMachine(
                         machineContext,
-                        `${machineContext.deposit.sourceTxHash}DepositMachine`,
+                        `${machineContext.deposit.sourceTxHash}`,
                     );
                 }
                 return machines;
@@ -423,9 +493,11 @@ export const mintConfig: Partial<MachineOptions<GatewayMachineContext, any>> = {
         }),
         listenerAction: listenerAction as any,
     },
+
     guards: {
-        isRequestCompleted: ({ signatureRequest }, evt) =>
-            evt.data?.sourceTxHash === signatureRequest && evt.data.destTxHash,
+        isRequestCompleted: ({ mintRequests }, evt) =>
+            (mintRequests || []).includes(evt.data?.sourceTxHash) &&
+            evt.data.destTxHash,
         isCompleted: ({ tx }, evt) =>
             evt.data?.sourceTxAmount >= tx.targetAmount,
         isExpired: ({ tx }) => tx.expiryTime < new Date().getTime(),

--- a/packages/lib/ren-tx/src/machines/burn.ts
+++ b/packages/lib/ren-tx/src/machines/burn.ts
@@ -7,6 +7,7 @@ import { LockChain, MintChain } from "@renproject/interfaces";
 import { assert } from "@renproject/utils";
 
 import { GatewaySession, GatewayTransaction } from "../types/transaction";
+import { log } from "xstate/lib/actions";
 
 export interface BurnMachineContext {
     /**
@@ -276,6 +277,7 @@ export const burnMachine = Machine<
                 },
             },
             errorBurning: {
+                entry: log((ctx, _evt) => ctx.tx.error, "ERROR"),
                 meta: {
                     test: (_: void, state: any) => {
                         assert(

--- a/packages/lib/ren-tx/src/machines/deposit.ts
+++ b/packages/lib/ren-tx/src/machines/deposit.ts
@@ -1,52 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO: Improve typings.
 
-import { Actor, assign, Machine, send, sendParent } from "xstate";
-import RenJS from "@renproject/ren";
-import { LockChain, MintChain } from "@renproject/interfaces";
-import { log } from "xstate/lib/actions";
+import { assign, Machine, send, sendParent } from "xstate";
+import { createModel } from "xstate/lib/model";
 import { assert } from "@renproject/utils";
 
-import { GatewaySession, GatewayTransaction } from "../types/transaction";
+import { GatewayTransaction } from "../types/transaction";
 
 /** The context that the deposit machine acts on */
 export interface DepositMachineContext {
     /** The deposit being tracked */
     deposit: GatewayTransaction;
-
-    /** The transaction session the deposit is part of */
-    tx: GatewaySession;
-
-    /**
-     * @private
-     * The internal xstate callback actor that recieves and sends events to the ren-js
-     * deposit
-     * */
-    depositListenerRef?: Actor<any>;
-
-    /**
-     * The blockchain providers required for constructing ren-js to/from parameters
-     * */
-    providers: any;
-
-    /**
-     * Functions to create the ren-js "from" param;
-     * */
-    fromChainMap: {
-        [key in string]: (
-            context: Omit<DepositMachineContext, "deposit">,
-        ) => LockChain<any>;
-    };
-
-    /**
-     * Functions to create the ren-js "to" param;
-     * */
-    toChainMap: {
-        [key in string]: (
-            context: Omit<DepositMachineContext, "deposit">,
-        ) => MintChain<any>;
-    };
-    sdk: RenJS;
 }
 
 /**  The states a deposit can be in */
@@ -91,9 +55,9 @@ export type DepositMachineEvent =
     | { type: "CHECK" }
     | { type: "LISTENING" }
     | { type: "DETECTED" }
-    | { type: "ERROR"; error: Error }
-    | { type: "RESTORE"; data: string }
-    | { type: "RESTORED"; data: string }
+    | { type: "ERROR"; data: GatewayTransaction; error: Error }
+    | { type: "RESTORE"; data: GatewayTransaction }
+    | { type: "RESTORED"; data: GatewayTransaction }
     | { type: "CONFIRMED" }
     | { type: "CONFIRMATION"; data: GatewayTransaction }
     | { type: "SIGNED"; data: GatewayTransaction }
@@ -104,6 +68,15 @@ export type DepositMachineEvent =
     | { type: "SUBMIT_ERROR"; data: Error }
     | { type: "ACKNOWLEDGE" };
 
+const depositModel = createModel<DepositMachineContext, DepositMachineEvent>({
+    deposit: {
+        sourceTxConfs: 0,
+        sourceTxHash: "",
+        sourceTxAmount: 0,
+        rawSourceTx: { amount: "0", transaction: {} },
+    },
+});
+
 /** Statemachine that tracks individual deposits */
 export const depositMachine = Machine<
     DepositMachineContext,
@@ -112,20 +85,9 @@ export const depositMachine = Machine<
 >(
     {
         id: "RenVMDepositTransaction",
+        context: depositModel.initialContext,
         initial: "checkingCompletion",
         states: {
-            errorRestoring: {
-                entry: [log("restore error")],
-                meta: {
-                    test: async (_: void, state: any) => {
-                        assert(
-                            state.context.deposit.error ? true : false,
-                            "error must exist",
-                        );
-                    },
-                },
-            },
-
             // Checking if deposit is completed so that we can skip initialization
             checkingCompletion: {
                 entry: [send("CHECK")],
@@ -144,62 +106,46 @@ export const depositMachine = Machine<
                 meta: {
                     test: async (_: void, state: any) => {
                         assert(
-                            !state.context.tx.error ? true : false,
+                            !state.context.deposit.error ? true : false,
                             "Error must not exist",
                         );
                     },
                 },
             },
-
-            // Setting up the ren-js listener for this deposit
-            restoringDeposit: {
-                entry: ["listenerAction"],
-                on: {
-                    LISTENING: {
-                        actions: send(
-                            (context) => {
-                                // If we don't have a raw tx, we can't restore
-                                if (context.deposit?.rawSourceTx) {
-                                    return {
-                                        type: "RESTORE",
-                                        data: context.deposit.rawSourceTx,
-                                    };
-                                } else {
-                                    return { type: "NOOP" };
-                                }
-                            },
-                            {
-                                to: (context) => {
-                                    // Named listener as ref does not seem to work
-                                    return `${context.deposit.sourceTxHash}DepositListener`;
-                                },
-                            },
-                        ),
+            errorRestoring: {
+                meta: {
+                    test: async (_: void, state: any) => {
+                        assert(
+                            state.context.deposit.error ? true : false,
+                            "Error must exist",
+                        );
                     },
+                },
+            },
 
-                    ERROR: [
-                        {
-                            target: "errorRestoring",
-                            actions: assign({
-                                deposit: (ctx, event) => ({
-                                    ...ctx.deposit,
-                                    error: event.error,
-                                }),
-                            }),
-                        },
-                    ],
+            restoringDeposit: {
+                entry: sendParent((c, _) => ({
+                    type: "RESTORE",
+                    data: c.deposit,
+                })),
 
-                    DETECTED: [
-                        {
-                            target: "restoredDeposit",
-                        },
-                    ],
+                on: {
+                    RESTORED: {
+                        target: "restoredDeposit",
+                        actions: assign((_, e) => ({ deposit: e.data })),
+                    },
+                    ERROR: {
+                        target: "errorRestoring",
+                        actions: assign((c, e) => ({
+                            deposit: { ...c.deposit, error: e.error },
+                        })),
+                    },
                 },
 
                 meta: {
                     test: async (_: void, state: any) => {
                         assert(
-                            !state.context.tx.error ? true : false,
+                            !state.context.deposit.error ? true : false,
                             "Error must not exist",
                         );
                     },
@@ -208,12 +154,10 @@ export const depositMachine = Machine<
 
             // Checking deposit internal state to transition to correct machine state
             restoredDeposit: {
+                // Parent must send restored
                 entry: [send("RESTORED")],
                 on: {
                     RESTORED: [
-                        {
-                            target: "errorRestoring",
-                        },
                         {
                             target: "srcSettling",
                             cond: "isSrcSettling",
@@ -236,12 +180,10 @@ export const depositMachine = Machine<
             },
 
             srcSettling: {
-                entry: send("SETTLE", {
-                    to: (context) => {
-                        const id = `${context.deposit.sourceTxHash}DepositListener`;
-                        return id;
-                    },
-                }),
+                entry: sendParent((ctx, _) => ({
+                    type: "SETTLE",
+                    hash: ctx.deposit.sourceTxHash,
+                })),
                 on: {
                     CONFIRMED: [
                         {
@@ -261,9 +203,14 @@ export const depositMachine = Machine<
                             ],
                         },
                     ],
+
                     CONFIRMATION: [
                         {
                             actions: [
+                                sendParent((ctx, evt) => ({
+                                    type: "DEPOSIT_UPDATE",
+                                    data: { ...ctx.deposit, ...evt.data },
+                                })),
                                 assign({
                                     deposit: (context, evt) => ({
                                         ...context.deposit,
@@ -273,10 +220,6 @@ export const depositMachine = Machine<
                                             evt.data?.sourceTxConfTarget || 1,
                                     }),
                                 }),
-                                sendParent((ctx, evt) => ({
-                                    type: "DEPOSIT_UPDATE",
-                                    data: { ...ctx.deposit, ...evt.data },
-                                })),
                             ],
                         },
                     ],
@@ -285,10 +228,10 @@ export const depositMachine = Machine<
             },
 
             srcConfirmed: {
-                entry: send("SIGN", {
-                    to: (context) =>
-                        `${context.deposit.sourceTxHash}DepositListener`,
-                }),
+                entry: sendParent((ctx, _) => ({
+                    type: "SIGN",
+                    hash: ctx.deposit.sourceTxHash,
+                })),
                 on: {
                     SIGN_ERROR: {
                         target: "errorAccepting",
@@ -375,16 +318,11 @@ export const depositMachine = Machine<
             },
 
             claiming: {
-                entry: send(
-                    (ctx) => ({
-                        type: "MINT",
-                        data: ctx.deposit.contractParams,
-                    }),
-                    {
-                        to: (context) =>
-                            `${context.deposit.sourceTxHash}DepositListener`,
-                    },
-                ),
+                entry: sendParent((ctx) => ({
+                    type: "MINT",
+                    hash: ctx.deposit.sourceTxHash,
+                    data: ctx.deposit.contractParams,
+                })),
                 on: {
                     SUBMIT_ERROR: [
                         {

--- a/packages/lib/ren-tx/src/machines/mint.ts
+++ b/packages/lib/ren-tx/src/machines/mint.ts
@@ -157,7 +157,7 @@ export const mintMachine = Machine<
                                 return newTx;
                             },
                         }),
-                        log((_ctx, evt) => evt.data),
+                        log((_ctx, evt) => evt.data, "ERROR"),
                     ],
                 },
             },
@@ -200,7 +200,7 @@ export const mintMachine = Machine<
                                 return newTx;
                             },
                         }),
-                        log((_ctx, evt) => evt.data),
+                        log((_ctx, evt) => evt.data, "ERROR"),
                     ],
                 },
 
@@ -223,6 +223,7 @@ export const mintMachine = Machine<
                 CONFIRMED: { actions: "routeEvent" },
                 ERROR: { actions: "routeEvent" },
                 SIGN_ERROR: { actions: "routeEvent" },
+                SUBMIT_ERROR: { actions: "routeEvent" },
                 SIGNED: { actions: "routeEvent" },
                 SUBMITTED: { actions: "routeEvent" },
 

--- a/packages/lib/ren-tx/src/machines/mint.ts
+++ b/packages/lib/ren-tx/src/machines/mint.ts
@@ -8,7 +8,7 @@ import { assert } from "@renproject/utils";
 import { log } from "xstate/lib/actions";
 
 import { GatewaySession, GatewayTransaction } from "../types/transaction";
-import { depositMachine } from "./deposit";
+import { depositMachine, DepositMachineEvent } from "./deposit";
 
 export interface GatewayMachineContext {
     /**
@@ -20,11 +20,10 @@ export interface GatewayMachineContext {
      */
     autoFees?: boolean;
     /**
-     * @private
-     * A reference to a deposit hash that is requesting a mint signature /
-     * tx submission
+     * A reference to a deposit hashes of transactions that can be
+     * minted on their destination chains
      */
-    signatureRequest?: string | null;
+    mintRequests?: string[];
     /**
      * @private
      * Keeps track of child machines that track underlying deposits
@@ -61,12 +60,12 @@ export interface GatewayMachineSchema {
         creating: {};
         srcInitializeError: {};
         listening: {};
-        requestingSignature: {};
         completed: {};
     };
 }
 
 export type GatewayMachineEvent =
+    | DepositMachineEvent
     | { type: "CLAIMABLE"; data: GatewayTransaction }
     | { type: "ERROR_LISTENING"; data: any }
     | { type: "DEPOSIT"; data: GatewayTransaction }
@@ -74,6 +73,8 @@ export type GatewayMachineEvent =
     | { type: "DEPOSIT_COMPLETED"; data: GatewayTransaction }
     | { type: "REQUEST_SIGNATURE"; data: GatewayTransaction }
     | { type: "SIGN"; data: GatewayTransaction }
+    | { type: "SETTLE"; data: GatewayTransaction }
+    | { type: "MINT"; data: GatewayTransaction }
     | { type: "EXPIRED"; data: GatewayTransaction }
     | { type: "ACKNOWLEDGE"; data: any }
     | { type: "RESTORE"; data: GatewayTransaction };
@@ -103,7 +104,10 @@ export const mintMachine = Machine<
         restoring: {
             entry: [
                 send("RESTORE"),
-                assign({ depositMachines: (_ctx, _evt) => ({}) }),
+                assign({
+                    mintRequests: (_c, _e) => [],
+                    depositMachines: (_ctx, _evt) => ({}),
+                }),
             ],
             meta: { test: async () => {} },
             on: {
@@ -200,29 +204,72 @@ export const mintMachine = Machine<
                     ],
                 },
 
+                RESTORED: {
+                    actions: "broadcast",
+                },
+
+                SETTLE: {
+                    actions: "forwardEvent",
+                },
+                SIGN: {
+                    actions: "forwardEvent",
+                },
+                MINT: {
+                    actions: "forwardEvent",
+                },
+
+                CLAIM: { actions: "routeEvent" },
+                CONFIRMATION: { actions: "routeEvent" },
+                CONFIRMED: { actions: "routeEvent" },
+                ERROR: { actions: "routeEvent" },
+                SIGN_ERROR: { actions: "routeEvent" },
+                SIGNED: { actions: "routeEvent" },
+                SUBMITTED: { actions: "routeEvent" },
+
                 CLAIMABLE: {
                     actions: assign({
-                        signatureRequest: (_context, evt) => {
-                            return evt.data?.sourceTxHash;
+                        mintRequests: (context, evt) => {
+                            const oldRequests = context.mintRequests || [];
+                            const newRequest = evt.data?.sourceTxHash;
+                            if (!newRequest) {
+                                return oldRequests;
+                            }
+
+                            if (oldRequests.includes(newRequest)) {
+                                return oldRequests;
+                            }
+                            return [...oldRequests, newRequest];
                         },
                         tx: (context, evt) => {
-                            if (evt.data?.sourceTxHash) {
+                            if (evt.data.sourceTxHash) {
                                 context.tx.transactions[evt.data.sourceTxHash] =
                                     evt.data;
                             }
                             return context.tx;
                         },
                     }),
-                    target: "requestingSignature",
                 },
 
                 DEPOSIT_COMPLETED: {
                     target: "completed",
                     cond: "isCompleted",
                 },
+
                 DEPOSIT_UPDATE: [
                     {
                         actions: assign({
+                            mintRequests: (ctx, evt) => {
+                                // check if completed
+                                if (evt.data.destTxHash) {
+                                    return (
+                                        ctx.mintRequests?.filter(
+                                            (x) => x !== evt.data.sourceTxHash,
+                                        ) || []
+                                    );
+                                } else {
+                                    return ctx.mintRequests;
+                                }
+                            },
                             tx: (context, evt) => {
                                 if (evt.data?.sourceTxHash) {
                                     context.tx.transactions[
@@ -256,50 +303,6 @@ export const mintMachine = Machine<
             },
         },
 
-        requestingSignature: {
-            on: {
-                SIGN: {
-                    target: "listening",
-                    actions: send("CLAIM", {
-                        to: (ctx) => {
-                            if (!ctx.depositMachines) return "";
-                            return ctx.depositMachines[
-                                ctx.signatureRequest || ""
-                            ];
-                        },
-                    }),
-                },
-
-                DEPOSIT_UPDATE: [
-                    {
-                        cond: "isRequestCompleted",
-                        actions: assign({
-                            signatureRequest: (_ctx, _evt) => null,
-                            tx: (ctx, evt) => {
-                                if (evt.data?.sourceTxHash) {
-                                    ctx.tx.transactions[evt.data.sourceTxHash] =
-                                        evt.data;
-                                }
-                                return ctx.tx;
-                            },
-                        }),
-                    },
-                ],
-            },
-
-            meta: {
-                test: (_: any, state: any) => {
-                    if (
-                        Object.keys(state.context.tx.transactions || {})
-                            .length === 0
-                    ) {
-                        throw Error(
-                            "A deposit must exist for a signature to be requested",
-                        );
-                    }
-                },
-            },
-        },
         completed: {
             meta: {
                 test: (_: any, state: any) => {

--- a/packages/lib/ren-tx/src/machines/mint.ts
+++ b/packages/lib/ren-tx/src/machines/mint.ts
@@ -255,6 +255,7 @@ export const mintMachine = Machine<
                 },
             },
         },
+
         requestingSignature: {
             on: {
                 SIGN: {
@@ -268,6 +269,7 @@ export const mintMachine = Machine<
                         },
                     }),
                 },
+
                 DEPOSIT_UPDATE: [
                     {
                         cond: "isRequestCompleted",
@@ -284,6 +286,7 @@ export const mintMachine = Machine<
                     },
                 ],
             },
+
             meta: {
                 test: (_: any, state: any) => {
                     if (

--- a/packages/lib/ren-tx/test/burn.spec.ts
+++ b/packages/lib/ren-tx/test/burn.spec.ts
@@ -1,10 +1,16 @@
 /* eslint-disable no-console */
 
 import RenJS from "@renproject/ren";
-import { interpret } from "xstate";
+import { EventObject, interpret, State } from "xstate";
 import { config as loadDotEnv } from "dotenv";
 
-import { burnConfig, burnMachine, GatewaySession } from "../src";
+import {
+    burnConfig,
+    burnMachine,
+    BurnMachineContext,
+    BurnMachineSchema,
+    GatewaySession,
+} from "../src";
 import { buildMockLockChain, buildMockMintChain } from "./testutils/mock";
 
 loadDotEnv();
@@ -52,9 +58,15 @@ describe("BurnMachine", () => {
         });
         let result: any = {};
 
-        const p = new Promise<any>((resolve) => {
+        const p = new Promise<
+            State<BurnMachineContext, EventObject, BurnMachineSchema>
+        >((resolve, reject) => {
             const service = interpret(machine)
                 .onTransition((state) => {
+                    console.log(state.value);
+                    if ((state.value as string).includes("error")) {
+                        reject(state.value);
+                    }
                     if (state.value === "srcSettling") {
                         // we have successfully created a burn tx
                         result = state;

--- a/packages/lib/ren-tx/test/machines.spec.ts
+++ b/packages/lib/ren-tx/test/machines.spec.ts
@@ -51,6 +51,9 @@ const mintModel = createModel(mintMachine).withEvents({
     SIGN_ERROR: {
         cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
     },
+    SUBMIT_ERROR: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
     SIGNED: {
         cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
     },

--- a/packages/lib/ren-tx/test/machines.spec.ts
+++ b/packages/lib/ren-tx/test/machines.spec.ts
@@ -36,6 +36,27 @@ mintMachine.config = mintConfig as any;
 mintMachine.context = makeTestContext() as any;
 const mintModel = createModel(mintMachine).withEvents({
     RESTORE: {},
+    CLAIM: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
+    CONFIRMED: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
+    CONFIRMATION: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
+    ERROR: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
+    SIGN_ERROR: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
+    SIGNED: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
+    SUBMITTED: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
     "done.invoke.txCreator": {
         exec: async () => {},
         cases: [
@@ -52,12 +73,15 @@ const mintModel = createModel(mintMachine).withEvents({
         cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
     },
     EXPIRED: {},
-    CLAIMABLE: {},
+    CLAIMABLE: {
+        cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
+    },
     ACKNOWLEDGE: {},
+    ERROR_LISTENING: {},
 });
 
 describe("MintMachine", function () {
-    const testPlans = mintModel.getShortestPathPlans();
+    const testPlans = mintModel.getSimplePathPlans();
     testPlans.forEach((plan) => {
         describe(plan.description, () => {
             plan.paths.forEach((path) => {
@@ -100,12 +124,16 @@ const depositModel = createModel(
     SUBMIT_ERROR: {
         cases: [{ data: { message: "an error" } }],
     },
-    RESTORED: {},
+    RESTORED: {
+        cases: [{ data: { sourceTxHash: "123" } }],
+    },
     CONFIRMATION: {},
     CONFIRMED: {},
     REJECT: {},
     SIGNED: {},
-    CLAIM: {},
+    CLAIM: {
+        cases: [{ data: { sourceTxHash: "123" } }],
+    },
     SUBMITTED: {},
     ACKNOWLEDGE: {},
 });

--- a/packages/lib/ren-tx/test/machines.spec.ts
+++ b/packages/lib/ren-tx/test/machines.spec.ts
@@ -162,6 +162,9 @@ const burnModel = createModel(
     CONFIRMED: {
         cases: [{ data: { sourceTxHash: "123", sourceTxConfs: 1 } }],
     },
+    ACCEPTED: {
+        cases: [{ data: { sourceTxHash: "123", sourceTxConfs: 1 } }],
+    },
     SUBMITTED: {
         cases: [{ data: { sourceTxHash: "123" } }],
     },

--- a/packages/lib/ren-tx/test/testutils/mock.ts
+++ b/packages/lib/ren-tx/test/testutils/mock.ts
@@ -7,7 +7,7 @@ const getConfs = (id: number) => {
     return confirmationRegistry[id];
 };
 
-export const buildMockLockChain = (conf = { targetConfirmations: 500 }) => {
+export const buildMockLockChain = (conf = { targetConfirmations: 50 }) => {
     const id = confirmationRegistry.length;
     confirmationRegistry[id] = 0;
     const transactionConfidence = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20435,20 +20435,15 @@ typeforce@^1.11.3, typeforce@^1.11.5:
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
-typescript@4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+typescript@4.1.3, typescript@^4.0.5:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 typescript@^3.7.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
-
-typescript@^4.0.5:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 ua-parser-js@^0.7.18:
   version "0.7.23"
@@ -22543,10 +22538,10 @@ xmlhttprequest@1.8.0:
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
   integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
-xstate@^4.13.0:
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.15.1.tgz#0553453c1cd201fedaf35a3cc518fe56090dbc3a"
-  integrity sha512-8dD/GnTwxUuDr/cY42vi+Enu4mpbuUXWISYJ0a9BC+cIFvqufJsepyDLS6lLsznfUP0GS5Yx9m3IQWFhAoGt/A==
+xstate@^4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.16.0.tgz#e434d0558c0f9a7e9212802834992a6c2f47bca6"
+  integrity sha512-2k/49QYLdzG6Ye1JQWYFuPdU6dnRqHXcuFLxuORiuel04GjApSPct7wp2SOz9RAlNME5EkzclRKw1fHm5yejuA==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This refactors the mint and deposit machines so that each deposit does
not need its own renjs lockAndMint instance, routing messages through
the mint machine instead.