### PR TITLE
feat(ren-js): add onlyInPayload parameter option

### DIFF
--- a/packages/lib/interfaces/src/ethArgs.ts
+++ b/packages/lib/interfaces/src/ethArgs.ts
@@ -120,6 +120,7 @@ export interface EthArg<
     type: type;
     value: valueType;
     notInPayload?: boolean;
+    onlyInPayload?: boolean;
 }
 
 export type EthArgs = EthArg[];

--- a/packages/lib/interfaces/src/ethArgs.ts
+++ b/packages/lib/interfaces/src/ethArgs.ts
@@ -119,7 +119,27 @@ export interface EthArg<
     name: name;
     type: type;
     value: valueType;
+
+    /**
+     * `notInPayload` indicates that the parameter should be used when calling
+     * the smart contract but it should not be used when calculating the
+     * payload hash. This is useful for values can only be known at the time
+     * of calling the contract. Note that others may be able to submit the mint
+     * and set their own value, unless the contract caller is restricted somehow.
+     */
     notInPayload?: boolean;
+
+    /**
+     * `onlyInPayload` indicates that the parameter should be used when
+     * calculating the payload hash but it should not be passed in to the
+     * contract call. This is useful for values that don't need to be explicitly
+     * passed in to the contract, such as the contract caller.
+     *
+     * `notInPayload` and `onlyInPayload` can be used together to allow users to
+     * update values such as exchange rate slippage, which may have updated
+     * while waiting for the lock-chain confirmations - while ensuring that
+     * others can't change it for them.
+     */
     onlyInPayload?: boolean;
 }
 


### PR DESCRIPTION
This PR adds a `onlyInPayload` option for contract call parameters that complements `notInPayload`. It will use the parameter's value for calculating the `pHash` but it won't include it when calling the smart contract.

The use case is for contracts like the WBTC.Cafe curve adapter which include values in the payload hash that aren't passed in directly as contract call parameters - for example `msg.sender`.