### PR TITLE
fix(ren-tx): restore multiple deposits correctly

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.1.1"
+    "version": "2.1.2-alpha.0"
 }

--- a/packages/lib/chains/chains-bitcoin/package.json
+++ b/packages/lib/chains/chains-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-bitcoin",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -44,9 +44,9 @@
     },
     "dependencies": {
         "@CoinSpace/bitcore-lib-dogecoin": "CoinSpace/bitcore-lib-dogecoin",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/bs58": "^4.0.1",
         "@types/cashaddrjs": "^0.3.0",
         "@types/node": ">=10",

--- a/packages/lib/chains/chains-ethereum/package.json
+++ b/packages/lib/chains/chains-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-ethereum",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,8 +43,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/chains/chains-filecoin/package.json
+++ b/packages/lib/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,9 +45,9 @@
     "dependencies": {
         "@glif/filecoin-address": "^1.1.0-beta.18",
         "@glif/filecoin-rpc-client": "^1.1.0-beta.17",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/elliptic": "^6.4.12",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/chains/chains-terra/package.json
+++ b/packages/lib/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@terra-money/terra.js": "1.3.6",
         "@types/node": ">=10",
         "bech32": "^1.1.4",

--- a/packages/lib/chains/chains/package.json
+++ b/packages/lib/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,11 +43,11 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^2.1.1",
-        "@renproject/chains-ethereum": "^2.1.1",
-        "@renproject/chains-filecoin": "^2.1.1",
-        "@renproject/chains-terra": "^2.1.1",
-        "@renproject/interfaces": "^2.1.1",
+        "@renproject/chains-bitcoin": "^2.1.2-alpha.0",
+        "@renproject/chains-ethereum": "^2.1.2-alpha.0",
+        "@renproject/chains-filecoin": "^2.1.2-alpha.0",
+        "@renproject/chains-terra": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/interfaces/package.json
+++ b/packages/lib/interfaces/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/interfaces",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/lib/multiwallet/multiwallet-abstract-ethereum-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-abstract-ethereum-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-abstract-ethereum-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/chains-ethereum": "^2.1.1",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/multiwallet-base-connector": "^2.1.1",
+        "@renproject/chains-ethereum": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "web3": "^2.0.0-alpha.1"
     },

--- a/packages/lib/multiwallet/multiwallet-base-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-base-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-base-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
         "@types/events": "3.0.0",
         "@types/node": ">=10",
         "events": "3.2.0"

--- a/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-binancesmartchain-injected-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,9 +41,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.1",
-        "@renproject/multiwallet-ethereum-injected-connector": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-ethereum-injected-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-injected-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-injected-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-injected-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,8 +41,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.1",
-        "@renproject/multiwallet-base-connector": "^2.1.1",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-mewconnect-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
     },
     "dependencies": {
         "@myetherwallet/mewconnect-web-client": "^2.1.5-beta.1",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.1",
-        "@renproject/multiwallet-base-connector": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-walletconnect-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-walletconnect-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-walletconnect-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,9 +41,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.1",
-        "@renproject/multiwallet-base-connector": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "@walletconnect/web3-provider": "^1.3.0-rc.0"
     },

--- a/packages/lib/provider/package.json
+++ b/packages/lib/provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/provider",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,8 +43,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "axios": "^0.21.1",
         "immutable": "^4.0.0-rc.12"

--- a/packages/lib/ren-tx/package.json
+++ b/packages/lib/ren-tx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren-tx",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "description": "XState Statemachines for tracking RenVM transactions reactively",
     "repository": {
         "type": "git",
@@ -45,9 +45,9 @@
         "bignumber.js": "^9.0.1"
     },
     "devDependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/ren": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/ren": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
         "dotenv": "^8.2.0",
         "xstate": "^4.16.0"
     },

--- a/packages/lib/ren-tx/src/configs/genericBurn.ts
+++ b/packages/lib/ren-tx/src/configs/genericBurn.ts
@@ -109,7 +109,10 @@ const performBurn = async (
     // will resume from previous tx if we have the hash
     const burnRef = burn.burn();
 
-    const burnListener = (confs: number, target: number) => {
+    const burnListener = async (
+        confs: number /* actually eth tx target: number */,
+    ) => {
+        const target = await burn.confirmationTarget();
         if (confs >= target) {
             // stop listening for confirmations once confirmed
             burnRef.removeListener("confirmation", burnListener);
@@ -162,7 +165,7 @@ const performBurn = async (
 
             // Always call because we won't get an emission
             // if the burn is already done
-            burnListener(tx.sourceTxConfs, target);
+            burnListener(tx.sourceTxConfs);
         }
     } catch (error) {
         throw error;

--- a/packages/lib/ren-tx/src/configs/genericBurn.ts
+++ b/packages/lib/ren-tx/src/configs/genericBurn.ts
@@ -113,7 +113,9 @@ const performBurn = async (
         confs: number /* actually eth tx target: number */,
     ) => {
         const target = await burn.confirmationTarget();
-        if (confs >= target) {
+        // We need to wait for burn details to resolve, which
+        // might not be ready even if we have sufficient confirmations
+        if (confs >= target && burn.burnDetails) {
             // stop listening for confirmations once confirmed
             burnRef.removeListener("confirmation", burnListener);
 

--- a/packages/lib/ren-tx/src/machines/deposit.ts
+++ b/packages/lib/ren-tx/src/machines/deposit.ts
@@ -239,7 +239,7 @@ export const depositMachine = Machine<
                                         sourceTxConfs:
                                             evt.data?.sourceTxConfs || 0,
                                         sourceTxConfTarget:
-                                            evt.data?.sourceTxConfTarget || 1,
+                                            evt.data?.sourceTxConfTarget,
                                     }),
                                 }),
                             ],
@@ -450,11 +450,15 @@ export const depositMachine = Machine<
         guards: {
             isSrcSettling: ({
                 deposit: { sourceTxConfs, sourceTxConfTarget },
-            }) => (sourceTxConfs || 0) < (sourceTxConfTarget || 1),
+            }) =>
+                (sourceTxConfs || 0) <
+                (sourceTxConfTarget || Number.POSITIVE_INFINITY), // If we don't know the target, keep settling
             isSrcConfirmed: () => false,
             isSrcSettled: ({
                 deposit: { sourceTxConfs, sourceTxConfTarget },
-            }) => (sourceTxConfs || 0) >= (sourceTxConfTarget || 1),
+            }) =>
+                (sourceTxConfs || 0) >=
+                (sourceTxConfTarget || Number.POSITIVE_INFINITY), // If we don't know the target, keep settling
             isAccepted: ({ deposit: { renSignature } }) =>
                 renSignature ? true : false,
             isDestInitiated: ({ deposit: { destTxHash } }) =>

--- a/packages/lib/ren-tx/src/machines/mint.ts
+++ b/packages/lib/ren-tx/src/machines/mint.ts
@@ -187,6 +187,8 @@ export const mintMachine = Machine<
             },
             on: {
                 EXPIRED: "completed",
+                // once we have ren-js listening for deposits,
+                // start the statemachines to determine deposit states
                 LISTENING: { actions: "depositMachineSpawner" },
                 ERROR_LISTENING: {
                     target: "srcInitializeError",
@@ -204,10 +206,7 @@ export const mintMachine = Machine<
                     ],
                 },
 
-                RESTORED: {
-                    actions: "broadcast",
-                },
-
+                // forward messages from child machines to renjs listeners
                 RESTORE: {
                     actions: "forwardEvent",
                 },
@@ -221,6 +220,10 @@ export const mintMachine = Machine<
                     actions: "forwardEvent",
                 },
 
+                // Send messages to child machines
+                RESTORED: {
+                    actions: "routeEvent",
+                },
                 CLAIM: { actions: "routeEvent" },
                 CONFIRMATION: { actions: "routeEvent" },
                 CONFIRMED: { actions: "routeEvent" },

--- a/packages/lib/ren-tx/test/machines.spec.ts
+++ b/packages/lib/ren-tx/test/machines.spec.ts
@@ -75,6 +75,9 @@ const mintModel = createModel(mintMachine).withEvents({
     DEPOSIT_UPDATE: {
         cases: [{ data: { sourceTxHash: "123", destTxHash: "123" } }],
     },
+    RESTORED: {
+        cases: [{ data: { sourceTxHash: "123" } }],
+    },
     EXPIRED: {},
     LISTENING: {},
     CLAIMABLE: {

--- a/packages/lib/ren/package.json
+++ b/packages/lib/ren/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "description": "Official Ren JavaScript SDK for bridging crypto assets cross-chain.",
     "repository": {
         "type": "git",
@@ -62,10 +62,10 @@
         "prepare-release": "run-s npmignore build doc:html doc:publish"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/provider": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/provider": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/rpc/package.json
+++ b/packages/lib/rpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/rpc",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "description": "Official Ren JavaScript client",
     "repository": {
         "type": "git",
@@ -53,9 +53,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/provider": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/provider": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "immutable": "^4.0.0-rc.12"

--- a/packages/lib/test/package.json
+++ b/packages/lib/test/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test",
     "private": true,
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "scripts": {
         "describe": "npm-scripts-info",
         "prettier": "yarn fix:prettier",
@@ -24,13 +24,13 @@
         "build:module": "tsc -p tsconfig.module.json"
     },
     "dependencies": {
-        "@renproject/chains": "^2.1.1",
-        "@renproject/chains-terra": "^2.1.1",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/provider": "^2.1.1",
-        "@renproject/ren": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/chains": "^2.1.2-alpha.0",
+        "@renproject/chains-terra": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/provider": "^2.1.2-alpha.0",
+        "@renproject/ren": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "immutable": "^4.0.0-rc.12",

--- a/packages/lib/utils/package.json
+++ b/packages/lib/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/utils",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,7 +43,7 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
         "@types/create-hash": "1.2.2",
         "@types/keccak": "^3.0.1",
         "@types/mocha": "^8.2.0",

--- a/packages/ui/multiwallet-ui/package.json
+++ b/packages/ui/multiwallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renproject/multiwallet-ui",
   "author": "renproject",
-  "version": "2.1.1",
+  "version": "2.1.2-alpha.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -28,8 +28,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@renproject/interfaces": "^2.1.1",
-    "@renproject/multiwallet-base-connector": "^2.1.1"
+    "@renproject/interfaces": "^2.1.2-alpha.0",
+    "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.11.0",


### PR DESCRIPTION
Currently, multiple deposits in ren-tx only work if they are processed end to end without restoring.

This fixes the issue by ensuring that machines get individual "RESTORED" events instead of a broadcasting the same event to all deposits