### PR TITLE
Fix confirmations for v0.2 chains/assets

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.1.2-alpha.1"
+    "version": "2.1.2-alpha.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.1.2-alpha.2"
+    "version": "2.1.2-alpha.3"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.1.2-alpha.0"
+    "version": "2.1.2-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.1.1"
+    "version": "2.1.2-alpha.0"
 }

--- a/packages/lib/chains/chains-bitcoin/package.json
+++ b/packages/lib/chains/chains-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-bitcoin",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -44,9 +44,9 @@
     },
     "dependencies": {
         "@CoinSpace/bitcore-lib-dogecoin": "CoinSpace/bitcore-lib-dogecoin",
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/rpc": "^2.1.2-alpha.0",
-        "@renproject/utils": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/rpc": "^2.1.2-alpha.1",
+        "@renproject/utils": "^2.1.2-alpha.1",
         "@types/bs58": "^4.0.1",
         "@types/cashaddrjs": "^0.3.0",
         "@types/node": ">=10",

--- a/packages/lib/chains/chains-bitcoin/package.json
+++ b/packages/lib/chains/chains-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-bitcoin",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -44,9 +44,9 @@
     },
     "dependencies": {
         "@CoinSpace/bitcore-lib-dogecoin": "CoinSpace/bitcore-lib-dogecoin",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/bs58": "^4.0.1",
         "@types/cashaddrjs": "^0.3.0",
         "@types/node": ">=10",

--- a/packages/lib/chains/chains-ethereum/package.json
+++ b/packages/lib/chains/chains-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-ethereum",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,8 +43,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/utils": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/utils": "^2.1.2-alpha.1",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/chains/chains-ethereum/package.json
+++ b/packages/lib/chains/chains-ethereum/package.json
@@ -50,7 +50,7 @@
         "bignumber.js": "^9.0.1",
         "bn.js": "^5.1.3",
         "bnc-sdk": "^3.0.0",
-        "ethereumjs-util": "^7.0.7",
+        "ethereumjs-util": "^7.0.8",
         "wallet-address-validator": "^0.2.4",
         "web3": "^2.0.0-alpha.1",
         "web3-core": "^2.0.0-alpha.1",

--- a/packages/lib/chains/chains-ethereum/package.json
+++ b/packages/lib/chains/chains-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-ethereum",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,8 +43,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/chains/chains-ethereum/src/base.ts
+++ b/packages/lib/chains/chains-ethereum/src/base.ts
@@ -385,6 +385,7 @@ export class EthereumBaseChain
 
         eventEmitter: EventEmitter,
         logger: Logger,
+        timeout?: number,
     ): Promise<BurnDetails<EthTransaction>> => {
         if (!this.renNetworkDetails || !this.web3) {
             throw new Error(
@@ -475,7 +476,7 @@ export class EthereumBaseChain
             throw new Error(`Unable to find burn from provided parameters.`);
         }
 
-        return extractBurnDetails(this.web3, transaction, logger);
+        return extractBurnDetails(this.web3, transaction, logger, timeout);
     };
 
     getFees = async (

--- a/packages/lib/chains/chains-ethereum/src/utils.ts
+++ b/packages/lib/chains/chains-ethereum/src/utils.ts
@@ -12,6 +12,7 @@ import {
     assertType,
     extractError,
     fromHex,
+    isDefined,
     Ox,
     payloadToABI,
     payloadToMintABI,
@@ -135,6 +136,7 @@ export const waitForReceipt = async (
     web3: Web3,
     txHash: string,
     logger?: Logger,
+    timeout?: number,
 ): Promise<TransactionReceipt> =>
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     new Promise<TransactionReceipt>(async (resolve, reject) => {
@@ -179,7 +181,7 @@ export const waitForReceipt = async (
             if (receipt && receipt.blockHash) {
                 break;
             }
-            await sleep(15 * SECONDS);
+            await sleep(isDefined(timeout) ? timeout : 15 * SECONDS);
         }
 
         try {
@@ -251,10 +253,11 @@ export const extractBurnDetails = async (
     web3: Web3,
     txHash: string,
     logger?: Logger,
+    timeout?: number,
 ): Promise<BurnDetails<EthTransaction>> => {
     assertType<string>("string", { txHash });
 
-    const receipt = await waitForReceipt(web3, txHash, logger);
+    const receipt = await waitForReceipt(web3, txHash, logger, timeout);
 
     if (!receipt.logs) {
         throw Error("No events found in transaction");

--- a/packages/lib/chains/chains-filecoin/package.json
+++ b/packages/lib/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,9 +45,9 @@
     "dependencies": {
         "@glif/filecoin-address": "^1.1.0-beta.18",
         "@glif/filecoin-rpc-client": "^1.1.0-beta.17",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/elliptic": "^6.4.12",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/chains/chains-filecoin/package.json
+++ b/packages/lib/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,9 +45,9 @@
     "dependencies": {
         "@glif/filecoin-address": "^1.1.0-beta.18",
         "@glif/filecoin-rpc-client": "^1.1.0-beta.17",
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/rpc": "^2.1.2-alpha.0",
-        "@renproject/utils": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/rpc": "^2.1.2-alpha.1",
+        "@renproject/utils": "^2.1.2-alpha.1",
         "@types/elliptic": "^6.4.12",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/chains/chains-terra/package.json
+++ b/packages/lib/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/rpc": "^2.1.2-alpha.0",
-        "@renproject/utils": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/rpc": "^2.1.2-alpha.1",
+        "@renproject/utils": "^2.1.2-alpha.1",
         "@terra-money/terra.js": "1.3.6",
         "@types/node": ">=10",
         "bech32": "^1.1.4",

--- a/packages/lib/chains/chains-terra/package.json
+++ b/packages/lib/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@terra-money/terra.js": "1.3.6",
         "@types/node": ">=10",
         "bech32": "^1.1.4",

--- a/packages/lib/chains/chains/package.json
+++ b/packages/lib/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,11 +43,11 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^2.1.2-alpha.0",
-        "@renproject/chains-ethereum": "^2.1.2-alpha.0",
-        "@renproject/chains-filecoin": "^2.1.2-alpha.0",
-        "@renproject/chains-terra": "^2.1.2-alpha.0",
-        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/chains-bitcoin": "^2.1.2-alpha.1",
+        "@renproject/chains-ethereum": "^2.1.2-alpha.1",
+        "@renproject/chains-filecoin": "^2.1.2-alpha.1",
+        "@renproject/chains-terra": "^2.1.2-alpha.1",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/chains/chains/package.json
+++ b/packages/lib/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,11 +43,11 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^2.1.1",
-        "@renproject/chains-ethereum": "^2.1.1",
-        "@renproject/chains-filecoin": "^2.1.1",
-        "@renproject/chains-terra": "^2.1.1",
-        "@renproject/interfaces": "^2.1.1",
+        "@renproject/chains-bitcoin": "^2.1.2-alpha.0",
+        "@renproject/chains-ethereum": "^2.1.2-alpha.0",
+        "@renproject/chains-filecoin": "^2.1.2-alpha.0",
+        "@renproject/chains-terra": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/interfaces/package.json
+++ b/packages/lib/interfaces/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/interfaces",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/lib/interfaces/package.json
+++ b/packages/lib/interfaces/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/interfaces",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/lib/interfaces/src/chain.ts
+++ b/packages/lib/interfaces/src/chain.ts
@@ -316,6 +316,7 @@ export interface MintChain<
 
         eventEmitter: EventEmitter,
         logger: Logger,
+        networkDelay?: number,
     ) => SyncOrPromise<BurnDetails<Transaction>>;
 
     /**

--- a/packages/lib/multiwallet/multiwallet-abstract-ethereum-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-abstract-ethereum-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-abstract-ethereum-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/chains-ethereum": "^2.1.1",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/multiwallet-base-connector": "^2.1.1",
+        "@renproject/chains-ethereum": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "web3": "^2.0.0-alpha.1"
     },

--- a/packages/lib/multiwallet/multiwallet-abstract-ethereum-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-abstract-ethereum-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-abstract-ethereum-connector",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/chains-ethereum": "^2.1.2-alpha.0",
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
+        "@renproject/chains-ethereum": "^2.1.2-alpha.1",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.1",
         "@types/node": ">=10",
         "web3": "^2.0.0-alpha.1"
     },

--- a/packages/lib/multiwallet/multiwallet-base-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-base-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-base-connector",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
         "@types/events": "3.0.0",
         "@types/node": ">=10",
         "events": "3.2.0"

--- a/packages/lib/multiwallet/multiwallet-base-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-base-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-base-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
         "@types/events": "3.0.0",
         "@types/node": ">=10",
         "events": "3.2.0"

--- a/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-binancesmartchain-injected-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,9 +41,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.1",
-        "@renproject/multiwallet-ethereum-injected-connector": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-ethereum-injected-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-binancesmartchain-injected-connector",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,9 +41,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
-        "@renproject/multiwallet-ethereum-injected-connector": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.1",
+        "@renproject/multiwallet-ethereum-injected-connector": "^2.1.2-alpha.1",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-injected-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-injected-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-injected-connector",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,8 +41,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
-        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.1",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.1",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-injected-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-injected-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-injected-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,8 +41,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.1",
-        "@renproject/multiwallet-base-connector": "^2.1.1",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-mewconnect-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
     },
     "dependencies": {
         "@myetherwallet/mewconnect-web-client": "^2.1.5-beta.1",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.1",
-        "@renproject/multiwallet-base-connector": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-mewconnect-connector",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
     },
     "dependencies": {
         "@myetherwallet/mewconnect-web-client": "^2.1.5-beta.1",
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
-        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.1",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.1",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-walletconnect-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-walletconnect-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-walletconnect-connector",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,9 +41,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
-        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.1",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.1",
         "@types/node": ">=10",
         "@walletconnect/web3-provider": "^1.3.0-rc.0"
     },

--- a/packages/lib/multiwallet/multiwallet-ethereum-walletconnect-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-walletconnect-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-walletconnect-connector",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,9 +41,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.1",
-        "@renproject/multiwallet-base-connector": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.1.2-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "@walletconnect/web3-provider": "^1.3.0-rc.0"
     },

--- a/packages/lib/provider/package.json
+++ b/packages/lib/provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/provider",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,8 +43,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "axios": "^0.21.1",
         "immutable": "^4.0.0-rc.12"

--- a/packages/lib/provider/package.json
+++ b/packages/lib/provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/provider",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,8 +43,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/utils": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/utils": "^2.1.2-alpha.1",
         "@types/node": ">=10",
         "axios": "^0.21.1",
         "immutable": "^4.0.0-rc.12"

--- a/packages/lib/ren-tx/package.json
+++ b/packages/lib/ren-tx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren-tx",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "description": "XState Statemachines for tracking RenVM transactions reactively",
     "repository": {
         "type": "git",
@@ -45,9 +45,9 @@
         "bignumber.js": "^9.0.1"
     },
     "devDependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/ren": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/ren": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
         "dotenv": "^8.2.0",
         "xstate": "^4.16.0"
     },

--- a/packages/lib/ren-tx/package.json
+++ b/packages/lib/ren-tx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren-tx",
-    "version": "2.1.2-alpha.1",
+    "version": "2.1.2-alpha.2",
     "description": "XState Statemachines for tracking RenVM transactions reactively",
     "repository": {
         "type": "git",

--- a/packages/lib/ren-tx/package.json
+++ b/packages/lib/ren-tx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren-tx",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "description": "XState Statemachines for tracking RenVM transactions reactively",
     "repository": {
         "type": "git",
@@ -45,9 +45,9 @@
         "bignumber.js": "^9.0.1"
     },
     "devDependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/ren": "^2.1.2-alpha.0",
-        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/ren": "^2.1.2-alpha.1",
+        "@renproject/rpc": "^2.1.2-alpha.1",
         "dotenv": "^8.2.0",
         "xstate": "^4.16.0"
     },

--- a/packages/lib/ren-tx/package.json
+++ b/packages/lib/ren-tx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren-tx",
-    "version": "2.1.2-alpha.2",
+    "version": "2.1.2-alpha.3",
     "description": "XState Statemachines for tracking RenVM transactions reactively",
     "repository": {
         "type": "git",

--- a/packages/lib/ren-tx/src/machines/deposit.ts
+++ b/packages/lib/ren-tx/src/machines/deposit.ts
@@ -200,7 +200,6 @@ export const depositMachine = Machine<
                                 assign({
                                     deposit: ({ deposit }, evt) => {
                                         if (deposit.sourceTxConfTarget) {
-                                            console.log("confirmed", evt);
                                             return {
                                                 ...deposit,
                                                 sourceTxConfs: largest(

--- a/packages/lib/ren-tx/test/burn.spec.ts
+++ b/packages/lib/ren-tx/test/burn.spec.ts
@@ -12,6 +12,7 @@ import {
     GatewaySession,
 } from "../src";
 import { buildMockLockChain, buildMockMintChain } from "./testutils/mock";
+import { SECONDS } from "@renproject/utils";
 
 loadDotEnv();
 const providers = {
@@ -50,7 +51,9 @@ describe("BurnMachine", () => {
 
         const machine = burnMachine.withConfig(burnConfig).withContext({
             tx: mintTransaction,
-            sdk: new RenJS("testnet"),
+            sdk: new RenJS("testnet", {
+                networkDelay: 1 * SECONDS,
+            }),
             autoSubmit: true,
             providers,
             fromChainMap,

--- a/packages/lib/ren-tx/test/mint.spec.ts
+++ b/packages/lib/ren-tx/test/mint.spec.ts
@@ -42,7 +42,7 @@ const makeMintTransaction = (): GatewaySession => ({
 
 const buildConfirmingMachine = (
     config: MockLockChainParams = {},
-    sdk = new RenJS("testnet", { networkDelay: 1 * SECONDS }),
+    sdk = new RenJS("testnet", { networkDelay: 0.5 * SECONDS }),
 ) => {
     const { mockLockChain, setConfirmations } = buildMockLockChain(config);
 
@@ -242,7 +242,7 @@ describe("MintMachine", () => {
         // We should have at least 2 confirmations by the time the second confirmation event fires
         setInterval(() => {
             setConfirmations((confirmations += 1));
-        }, 10000);
+        }, 1000);
 
         const p = new Promise((resolve, reject) => {
             let subscribed = false;
@@ -358,7 +358,7 @@ describe("MintMachine", () => {
                 },
             },
             sdk: new RenJS(renVMProvider, {
-                networkDelay: 1 * SECONDS,
+                networkDelay: 0.5 * SECONDS,
                 logLevel: "debug",
             }),
             providers,
@@ -369,7 +369,7 @@ describe("MintMachine", () => {
         let confirmations = 0;
         setInterval(() => {
             setConfirmations((confirmations += 1));
-        }, 5000);
+        }, 1000);
 
         const p = new Promise((resolve, reject) => {
             let subscribed = false;
@@ -503,7 +503,7 @@ describe("MintMachine", () => {
                     },
                 },
             },
-            sdk: new RenJS(renVMProvider, { networkDelay: 1 * SECONDS }),
+            sdk: new RenJS(renVMProvider, { networkDelay: 0.5 * SECONDS }),
             providers,
             fromChainMap,
             toChainMap,
@@ -512,7 +512,7 @@ describe("MintMachine", () => {
         let confirmations = 0;
         setInterval(() => {
             setConfirmations((confirmations += 1));
-        }, 5000);
+        }, 1000);
 
         const p = new Promise((resolve, reject) => {
             let subscribed: { [key: string]: boolean } = {};
@@ -626,7 +626,7 @@ describe("MintMachine", () => {
                     },
                 },
             },
-            sdk: new RenJS(renVMProvider, { networkDelay: 1 * SECONDS }), // , { logLevel: "debug" }),
+            sdk: new RenJS(renVMProvider, { networkDelay: 0.5 * SECONDS }), // , { logLevel: "debug" }),
             providers,
             fromChainMap,
             toChainMap,
@@ -635,7 +635,7 @@ describe("MintMachine", () => {
         let confirmations = 0;
         setInterval(() => {
             setConfirmations((confirmations += 1));
-        }, 10000);
+        }, 1000);
 
         const p = new Promise((resolve, reject) => {
             let subscribed = false;

--- a/packages/lib/ren-tx/test/mint.spec.ts
+++ b/packages/lib/ren-tx/test/mint.spec.ts
@@ -71,7 +71,7 @@ const buildConfirmingMachine = (
     return { machine, setConfirmations };
 };
 
-jest.setTimeout(1000 * 66);
+jest.setTimeout(1000 * 500);
 describe("MintMachine", () => {
     it("should create a tx", async () => {
         const { machine } = buildConfirmingMachine();

--- a/packages/lib/ren-tx/test/mint.spec.ts
+++ b/packages/lib/ren-tx/test/mint.spec.ts
@@ -18,6 +18,7 @@ import {
     buildMockMintChain,
     MockLockChainParams,
 } from "./testutils/mock";
+import { SECONDS } from "@renproject/utils";
 
 loadDotEnv();
 const providers = {
@@ -41,7 +42,7 @@ const makeMintTransaction = (): GatewaySession => ({
 
 const buildConfirmingMachine = (
     config: MockLockChainParams = {},
-    sdk = new RenJS("testnet"),
+    sdk = new RenJS("testnet", { networkDelay: 1 * SECONDS }),
 ) => {
     const { mockLockChain, setConfirmations } = buildMockLockChain(config);
 
@@ -233,7 +234,7 @@ describe("MintMachine", () => {
             {
                 targetConfirmations: 2,
             },
-            new RenJS(renVMProvider),
+            new RenJS(renVMProvider, { networkDelay: 1 * SECONDS }),
         );
 
         let confirmations = 0;
@@ -356,7 +357,10 @@ describe("MintMachine", () => {
                     },
                 },
             },
-            sdk: new RenJS(renVMProvider, { logLevel: "debug" }),
+            sdk: new RenJS(renVMProvider, {
+                networkDelay: 1 * SECONDS,
+                logLevel: "debug",
+            }),
             providers,
             fromChainMap,
             toChainMap,
@@ -499,7 +503,7 @@ describe("MintMachine", () => {
                     },
                 },
             },
-            sdk: new RenJS(renVMProvider),
+            sdk: new RenJS(renVMProvider, { networkDelay: 1 * SECONDS }),
             providers,
             fromChainMap,
             toChainMap,
@@ -622,7 +626,7 @@ describe("MintMachine", () => {
                     },
                 },
             },
-            sdk: new RenJS(renVMProvider), // , { logLevel: "debug" }),
+            sdk: new RenJS(renVMProvider, { networkDelay: 1 * SECONDS }), // , { logLevel: "debug" }),
             providers,
             fromChainMap,
             toChainMap,

--- a/packages/lib/ren/package.json
+++ b/packages/lib/ren/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "description": "Official Ren JavaScript SDK for bridging crypto assets cross-chain.",
     "repository": {
         "type": "git",
@@ -62,10 +62,10 @@
         "prepare-release": "run-s npmignore build doc:html doc:publish"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/provider": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/provider": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/ren/package.json
+++ b/packages/lib/ren/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "description": "Official Ren JavaScript SDK for bridging crypto assets cross-chain.",
     "repository": {
         "type": "git",
@@ -62,10 +62,10 @@
         "prepare-release": "run-s npmignore build doc:html doc:publish"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/provider": "^2.1.2-alpha.0",
-        "@renproject/rpc": "^2.1.2-alpha.0",
-        "@renproject/utils": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/provider": "^2.1.2-alpha.1",
+        "@renproject/rpc": "^2.1.2-alpha.1",
+        "@renproject/utils": "^2.1.2-alpha.1",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/ren/src/config.ts
+++ b/packages/lib/ren/src/config.ts
@@ -1,0 +1,20 @@
+import { Logger, LogLevelString } from "@renproject/interfaces";
+
+export interface RenJSConfig {
+    /**
+     * The logger and logLevel are used to configure where RenJS sends debug
+     * and error logs. Set the logLevel to `LogLevel.Debug` or `LogLevel.Trace`
+     * to receive debug logs.
+     */
+    logLevel?: LogLevelString;
+    logger?: Logger;
+
+    /**
+     * `networkDelay` is the timeout in ms between retrying various network
+     * requests including 1) fetching deposits, 2) fetching confirmations and
+     * 3) fetching a transaction's RenVM status.
+     *
+     * It defaults to `15000` (15 seconds).
+     */
+    networkDelay?: number;
+}

--- a/packages/lib/ren/src/index.ts
+++ b/packages/lib/ren/src/index.ts
@@ -20,13 +20,9 @@ import {
 import BigNumber from "bignumber.js";
 
 import { BurnAndRelease } from "./burnAndRelease";
+import { RenJSConfig } from "./config";
 import { defaultDepositHandler } from "./defaultDepositHandler";
 import { LockAndMint } from "./lockAndMint";
-
-export interface RenJSConfig {
-    logLevel?: LogLevelString;
-    logger?: Logger;
-}
 
 /**
  * This is the main exported class from `@renproject/ren`.
@@ -110,6 +106,8 @@ export default class RenJS {
 
     private readonly _logger: Logger;
 
+    private readonly _config: RenJSConfig;
+
     /**
      * Accepts the name of a network, or a network object.
      *
@@ -137,9 +135,12 @@ export default class RenJS {
         //     config = providerOrConfig as RenJSConfig;
         // }
 
+        this._config = config || {};
         this._logger =
             (config && config.logger) ||
             new SimpleLogger((config && config.logLevel) || LogLevel.Error);
+
+        this._config.logger = this._logger;
 
         // Use provided provider, provider URL or default lightnode URL.
         this.renVM =
@@ -247,7 +248,7 @@ export default class RenJS {
         new LockAndMint<Transaction, Deposit, Address>(
             this.renVM,
             params,
-            this._logger,
+            this._config,
         )._initialize();
 
     /**
@@ -266,7 +267,7 @@ export default class RenJS {
         new BurnAndRelease<Transaction, Deposit, Address>(
             this.renVM,
             params,
-            this._logger,
+            this._config,
         )._initialize();
 }
 

--- a/packages/lib/rpc/package.json
+++ b/packages/lib/rpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/rpc",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "description": "Official Ren JavaScript client",
     "repository": {
         "type": "git",
@@ -53,9 +53,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/provider": "^2.1.2-alpha.0",
-        "@renproject/utils": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/provider": "^2.1.2-alpha.1",
+        "@renproject/utils": "^2.1.2-alpha.1",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "immutable": "^4.0.0-rc.12"

--- a/packages/lib/rpc/package.json
+++ b/packages/lib/rpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/rpc",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "description": "Official Ren JavaScript client",
     "repository": {
         "type": "git",
@@ -53,9 +53,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/provider": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/provider": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "immutable": "^4.0.0-rc.12"

--- a/packages/lib/rpc/src/abstract.ts
+++ b/packages/lib/rpc/src/abstract.ts
@@ -109,6 +109,7 @@ export interface AbstractRenVMProvider<
         utxoTxHash: Buffer,
         onStatus?: (status: TxStatus) => void,
         _cancelRequested?: () => boolean,
+        timeout?: number,
     ) => SyncOrPromise<T>;
 
     /**

--- a/packages/lib/rpc/src/combinedProvider.ts
+++ b/packages/lib/rpc/src/combinedProvider.ts
@@ -199,7 +199,7 @@ export class CombinedProvider
         chain: { name: string },
     ) =>
         this.v1 && isV1Selector(selector)
-            ? undefined
+            ? this.v1.getConfirmationTarget(selector, chain)
             : this.v2.getConfirmationTarget(selector, chain);
 
     public estimateTransactionFee = async (

--- a/packages/lib/rpc/src/combinedProvider.ts
+++ b/packages/lib/rpc/src/combinedProvider.ts
@@ -151,6 +151,7 @@ export class CombinedProvider
         utxoTxHash: Buffer,
         onStatus?: (status: TxStatus) => void,
         cancelRequested?: () => boolean,
+        timeout?: number,
     ): SyncOrPromise<T> =>
         this.v1 && isV1Selector(selector)
             ? this.v1.waitForTX<T>(
@@ -158,12 +159,14 @@ export class CombinedProvider
                   utxoTxHash,
                   onStatus,
                   cancelRequested,
+                  timeout,
               )
             : this.v2.waitForTX<T>(
                   selector,
                   utxoTxHash,
                   onStatus,
                   cancelRequested,
+                  timeout,
               );
 
     /**

--- a/packages/lib/rpc/src/v1/renVMProvider.ts
+++ b/packages/lib/rpc/src/v1/renVMProvider.ts
@@ -18,6 +18,7 @@ import {
     assertType,
     extractError,
     fromBase64,
+    isDefined,
     keccak256,
     parseV1Selector,
     SECONDS,
@@ -388,6 +389,7 @@ export class RenVMProvider
         utxoTxHash: Buffer,
         onStatus?: (status: TxStatus) => void,
         _cancelRequested?: () => boolean,
+        timeout?: number,
     ): Promise<T> => {
         assertType<Buffer>("Buffer", { utxoTxHash });
         let rawResponse;
@@ -419,7 +421,7 @@ export class RenVMProvider
                     // TODO: throw unexpected errors
                 }
             }
-            await sleep(15 * SECONDS);
+            await sleep(isDefined(timeout) ? timeout : 15 * SECONDS);
         }
         return rawResponse;
     };

--- a/packages/lib/rpc/src/v1/renVMProvider.ts
+++ b/packages/lib/rpc/src/v1/renVMProvider.ts
@@ -475,6 +475,40 @@ export class RenVMProvider
         return this.network;
     };
 
+    public getConfirmationTarget = async (
+        selector: string,
+        _chain: { name: string },
+    ) => {
+        const { asset } = parseV1Selector(selector);
+        switch (this.network) {
+            case "mainnet":
+                switch (asset) {
+                    case "BTC":
+                        return 6;
+                    case "ZEC":
+                        return 24;
+                    case "BCH":
+                        return 15;
+                    case "ETH":
+                        return 30;
+                }
+                break;
+            case "testnet":
+                switch (asset) {
+                    case "BTC":
+                        return 2;
+                    case "ZEC":
+                        return 6;
+                    case "BCH":
+                        return 2;
+                    case "ETH":
+                        return 12;
+                }
+                break;
+        }
+        return undefined;
+    };
+
     public estimateTransactionFee = async (
         _selector: string,
         chain: { name: string; legacyName?: string },

--- a/packages/lib/rpc/src/v2/renVMProvider.ts
+++ b/packages/lib/rpc/src/v2/renVMProvider.ts
@@ -15,6 +15,7 @@ import { HttpProvider, Provider } from "@renproject/provider";
 import {
     assertType,
     fromBase64,
+    isDefined,
     SECONDS,
     sleep,
     toURLBase64,
@@ -325,6 +326,7 @@ export class RenVMProvider
         utxoTxHash: Buffer,
         onStatus?: (status: TxStatus) => void,
         _cancelRequested?: () => boolean,
+        timeout?: number,
     ): Promise<T> => {
         assertType<Buffer>("Buffer", { utxoTxHash });
         let rawResponse: T;
@@ -356,7 +358,7 @@ export class RenVMProvider
                     // TODO: throw unexpected errors
                 }
             }
-            await sleep(15 * SECONDS);
+            await sleep(isDefined(timeout) ? timeout : 15 * SECONDS);
         }
         return rawResponse;
     };

--- a/packages/lib/test/package.json
+++ b/packages/lib/test/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test",
     "private": true,
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "scripts": {
         "describe": "npm-scripts-info",
         "prettier": "yarn fix:prettier",
@@ -24,13 +24,13 @@
         "build:module": "tsc -p tsconfig.module.json"
     },
     "dependencies": {
-        "@renproject/chains": "^2.1.1",
-        "@renproject/chains-terra": "^2.1.1",
-        "@renproject/interfaces": "^2.1.1",
-        "@renproject/provider": "^2.1.1",
-        "@renproject/ren": "^2.1.1",
-        "@renproject/rpc": "^2.1.1",
-        "@renproject/utils": "^2.1.1",
+        "@renproject/chains": "^2.1.2-alpha.0",
+        "@renproject/chains-terra": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/provider": "^2.1.2-alpha.0",
+        "@renproject/ren": "^2.1.2-alpha.0",
+        "@renproject/rpc": "^2.1.2-alpha.0",
+        "@renproject/utils": "^2.1.2-alpha.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "immutable": "^4.0.0-rc.12",

--- a/packages/lib/test/package.json
+++ b/packages/lib/test/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test",
     "private": true,
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "scripts": {
         "describe": "npm-scripts-info",
         "prettier": "yarn fix:prettier",
@@ -24,13 +24,13 @@
         "build:module": "tsc -p tsconfig.module.json"
     },
     "dependencies": {
-        "@renproject/chains": "^2.1.2-alpha.0",
-        "@renproject/chains-terra": "^2.1.2-alpha.0",
-        "@renproject/interfaces": "^2.1.2-alpha.0",
-        "@renproject/provider": "^2.1.2-alpha.0",
-        "@renproject/ren": "^2.1.2-alpha.0",
-        "@renproject/rpc": "^2.1.2-alpha.0",
-        "@renproject/utils": "^2.1.2-alpha.0",
+        "@renproject/chains": "^2.1.2-alpha.1",
+        "@renproject/chains-terra": "^2.1.2-alpha.1",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
+        "@renproject/provider": "^2.1.2-alpha.1",
+        "@renproject/ren": "^2.1.2-alpha.1",
+        "@renproject/rpc": "^2.1.2-alpha.1",
+        "@renproject/utils": "^2.1.2-alpha.1",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "immutable": "^4.0.0-rc.12",

--- a/packages/lib/utils/package.json
+++ b/packages/lib/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/utils",
-    "version": "2.1.2-alpha.0",
+    "version": "2.1.2-alpha.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,7 +43,7 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.2-alpha.0",
+        "@renproject/interfaces": "^2.1.2-alpha.1",
         "@types/create-hash": "1.2.2",
         "@types/keccak": "^3.0.1",
         "@types/mocha": "^8.2.0",

--- a/packages/lib/utils/package.json
+++ b/packages/lib/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/utils",
-    "version": "2.1.1",
+    "version": "2.1.2-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,7 +43,7 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.1.1",
+        "@renproject/interfaces": "^2.1.2-alpha.0",
         "@types/create-hash": "1.2.2",
         "@types/keccak": "^3.0.1",
         "@types/mocha": "^8.2.0",

--- a/packages/ui/multiwallet-ui/package.json
+++ b/packages/ui/multiwallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renproject/multiwallet-ui",
   "author": "renproject",
-  "version": "2.1.1",
+  "version": "2.1.2-alpha.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -28,8 +28,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@renproject/interfaces": "^2.1.1",
-    "@renproject/multiwallet-base-connector": "^2.1.1"
+    "@renproject/interfaces": "^2.1.2-alpha.0",
+    "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.11.0",

--- a/packages/ui/multiwallet-ui/package.json
+++ b/packages/ui/multiwallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renproject/multiwallet-ui",
   "author": "renproject",
-  "version": "2.1.2-alpha.0",
+  "version": "2.1.2-alpha.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -28,8 +28,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@renproject/interfaces": "^2.1.2-alpha.0",
-    "@renproject/multiwallet-base-connector": "^2.1.2-alpha.0"
+    "@renproject/interfaces": "^2.1.2-alpha.1",
+    "@renproject/multiwallet-base-connector": "^2.1.2-alpha.1"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9932,7 +9932,7 @@ ethereumjs-util@^6.0.0:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
-ethereumjs-util@^7.0.7:
+ethereumjs-util@^7.0.8:
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.8.tgz#5258762b7b17e3d828e41834948363ff0a703ffd"
   integrity sha512-JJt7tDpCAmDPw/sGoFYeq0guOVqT3pTE9xlEbBmc/nlCij3JRCoS2c96SQ6kXVHOT3xWUNLDm5QCJLQaUnVAtQ==


### PR DESCRIPTION
Currently there's no confirmations method in the v1 rpc class, so the default conformations are used instead.
This PR hard-codes the confirmations for the v0.2 chains and assets.