### PR TITLE
Add config to configure delay when making repeated network requests

### DIFF
--- a/packages/lib/chains/chains-ethereum/package.json
+++ b/packages/lib/chains/chains-ethereum/package.json
@@ -50,7 +50,7 @@
         "bignumber.js": "^9.0.1",
         "bn.js": "^5.1.3",
         "bnc-sdk": "^3.0.0",
-        "ethereumjs-util": "^7.0.7",
+        "ethereumjs-util": "^7.0.8",
         "wallet-address-validator": "^0.2.4",
         "web3": "^2.0.0-alpha.1",
         "web3-core": "^2.0.0-alpha.1",

--- a/packages/lib/chains/chains-ethereum/src/base.ts
+++ b/packages/lib/chains/chains-ethereum/src/base.ts
@@ -385,6 +385,7 @@ export class EthereumBaseChain
 
         eventEmitter: EventEmitter,
         logger: Logger,
+        timeout?: number,
     ): Promise<BurnDetails<EthTransaction>> => {
         if (!this.renNetworkDetails || !this.web3) {
             throw new Error(
@@ -475,7 +476,7 @@ export class EthereumBaseChain
             throw new Error(`Unable to find burn from provided parameters.`);
         }
 
-        return extractBurnDetails(this.web3, transaction, logger);
+        return extractBurnDetails(this.web3, transaction, logger, timeout);
     };
 
     getFees = async (

--- a/packages/lib/chains/chains-ethereum/src/utils.ts
+++ b/packages/lib/chains/chains-ethereum/src/utils.ts
@@ -12,6 +12,7 @@ import {
     assertType,
     extractError,
     fromHex,
+    isDefined,
     Ox,
     payloadToABI,
     payloadToMintABI,
@@ -135,6 +136,7 @@ export const waitForReceipt = async (
     web3: Web3,
     txHash: string,
     logger?: Logger,
+    timeout?: number,
 ): Promise<TransactionReceipt> =>
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     new Promise<TransactionReceipt>(async (resolve, reject) => {
@@ -179,7 +181,7 @@ export const waitForReceipt = async (
             if (receipt && receipt.blockHash) {
                 break;
             }
-            await sleep(15 * SECONDS);
+            await sleep(isDefined(timeout) ? timeout : 15 * SECONDS);
         }
 
         try {
@@ -251,10 +253,11 @@ export const extractBurnDetails = async (
     web3: Web3,
     txHash: string,
     logger?: Logger,
+    timeout?: number,
 ): Promise<BurnDetails<EthTransaction>> => {
     assertType<string>("string", { txHash });
 
-    const receipt = await waitForReceipt(web3, txHash, logger);
+    const receipt = await waitForReceipt(web3, txHash, logger, timeout);
 
     if (!receipt.logs) {
         throw Error("No events found in transaction");

--- a/packages/lib/interfaces/src/chain.ts
+++ b/packages/lib/interfaces/src/chain.ts
@@ -316,6 +316,7 @@ export interface MintChain<
 
         eventEmitter: EventEmitter,
         logger: Logger,
+        networkDelay?: number,
     ) => SyncOrPromise<BurnDetails<Transaction>>;
 
     /**

--- a/packages/lib/ren-tx/test/burn.spec.ts
+++ b/packages/lib/ren-tx/test/burn.spec.ts
@@ -12,6 +12,7 @@ import {
     GatewaySession,
 } from "../src";
 import { buildMockLockChain, buildMockMintChain } from "./testutils/mock";
+import { SECONDS } from "@renproject/utils";
 
 loadDotEnv();
 const providers = {
@@ -50,7 +51,9 @@ describe("BurnMachine", () => {
 
         const machine = burnMachine.withConfig(burnConfig).withContext({
             tx: mintTransaction,
-            sdk: new RenJS("testnet"),
+            sdk: new RenJS("testnet", {
+                networkDelay: 1 * SECONDS,
+            }),
             autoSubmit: true,
             providers,
             fromChainMap,

--- a/packages/lib/ren-tx/test/mint.spec.ts
+++ b/packages/lib/ren-tx/test/mint.spec.ts
@@ -71,7 +71,7 @@ const buildConfirmingMachine = (
     return { machine, setConfirmations };
 };
 
-jest.setTimeout(1000 * 66);
+jest.setTimeout(1000 * 500);
 describe("MintMachine", () => {
     it("should create a tx", async () => {
         const { machine } = buildConfirmingMachine();

--- a/packages/lib/ren-tx/test/mint.spec.ts
+++ b/packages/lib/ren-tx/test/mint.spec.ts
@@ -18,6 +18,7 @@ import {
     buildMockMintChain,
     MockLockChainParams,
 } from "./testutils/mock";
+import { SECONDS } from "@renproject/utils";
 
 loadDotEnv();
 const providers = {
@@ -41,7 +42,7 @@ const makeMintTransaction = (): GatewaySession => ({
 
 const buildConfirmingMachine = (
     config: MockLockChainParams = {},
-    sdk = new RenJS("testnet"),
+    sdk = new RenJS("testnet", { networkDelay: 1 * SECONDS }),
 ) => {
     const { mockLockChain, setConfirmations } = buildMockLockChain(config);
 
@@ -233,7 +234,7 @@ describe("MintMachine", () => {
             {
                 targetConfirmations: 2,
             },
-            new RenJS(renVMProvider),
+            new RenJS(renVMProvider, { networkDelay: 1 * SECONDS }),
         );
 
         let confirmations = 0;
@@ -356,7 +357,10 @@ describe("MintMachine", () => {
                     },
                 },
             },
-            sdk: new RenJS(renVMProvider, { logLevel: "debug" }),
+            sdk: new RenJS(renVMProvider, {
+                networkDelay: 1 * SECONDS,
+                logLevel: "debug",
+            }),
             providers,
             fromChainMap,
             toChainMap,
@@ -499,7 +503,7 @@ describe("MintMachine", () => {
                     },
                 },
             },
-            sdk: new RenJS(renVMProvider),
+            sdk: new RenJS(renVMProvider, { networkDelay: 1 * SECONDS }),
             providers,
             fromChainMap,
             toChainMap,
@@ -622,7 +626,7 @@ describe("MintMachine", () => {
                     },
                 },
             },
-            sdk: new RenJS(renVMProvider), // , { logLevel: "debug" }),
+            sdk: new RenJS(renVMProvider, { networkDelay: 1 * SECONDS }), // , { logLevel: "debug" }),
             providers,
             fromChainMap,
             toChainMap,

--- a/packages/lib/ren/src/config.ts
+++ b/packages/lib/ren/src/config.ts
@@ -1,0 +1,20 @@
+import { Logger, LogLevelString } from "@renproject/interfaces";
+
+export interface RenJSConfig {
+    /**
+     * The logger and logLevel are used to configure where RenJS sends debug
+     * and error logs. Set the logLevel to `LogLevel.Debug` or `LogLevel.Trace`
+     * to receive debug logs.
+     */
+    logLevel?: LogLevelString;
+    logger?: Logger;
+
+    /**
+     * `networkDelay` is the timeout in ms between retrying various network
+     * requests including 1) fetching deposits, 2) fetching confirmations and
+     * 3) fetching a transaction's RenVM status.
+     *
+     * It defaults to `15000` (15 seconds).
+     */
+    networkDelay?: number;
+}

--- a/packages/lib/ren/src/index.ts
+++ b/packages/lib/ren/src/index.ts
@@ -20,13 +20,9 @@ import {
 import BigNumber from "bignumber.js";
 
 import { BurnAndRelease } from "./burnAndRelease";
+import { RenJSConfig } from "./config";
 import { defaultDepositHandler } from "./defaultDepositHandler";
 import { LockAndMint } from "./lockAndMint";
-
-export interface RenJSConfig {
-    logLevel?: LogLevelString;
-    logger?: Logger;
-}
 
 /**
  * This is the main exported class from `@renproject/ren`.
@@ -110,6 +106,8 @@ export default class RenJS {
 
     private readonly _logger: Logger;
 
+    private readonly _config: RenJSConfig;
+
     /**
      * Accepts the name of a network, or a network object.
      *
@@ -137,9 +135,12 @@ export default class RenJS {
         //     config = providerOrConfig as RenJSConfig;
         // }
 
+        this._config = config || {};
         this._logger =
             (config && config.logger) ||
             new SimpleLogger((config && config.logLevel) || LogLevel.Error);
+
+        this._config.logger = this._logger;
 
         // Use provided provider, provider URL or default lightnode URL.
         this.renVM =
@@ -247,7 +248,7 @@ export default class RenJS {
         new LockAndMint<Transaction, Deposit, Address>(
             this.renVM,
             params,
-            this._logger,
+            this._config,
         )._initialize();
 
     /**
@@ -266,7 +267,7 @@ export default class RenJS {
         new BurnAndRelease<Transaction, Deposit, Address>(
             this.renVM,
             params,
-            this._logger,
+            this._config,
         )._initialize();
 }
 

--- a/packages/lib/rpc/src/abstract.ts
+++ b/packages/lib/rpc/src/abstract.ts
@@ -109,6 +109,7 @@ export interface AbstractRenVMProvider<
         utxoTxHash: Buffer,
         onStatus?: (status: TxStatus) => void,
         _cancelRequested?: () => boolean,
+        timeout?: number,
     ) => SyncOrPromise<T>;
 
     /**

--- a/packages/lib/rpc/src/combinedProvider.ts
+++ b/packages/lib/rpc/src/combinedProvider.ts
@@ -151,6 +151,7 @@ export class CombinedProvider
         utxoTxHash: Buffer,
         onStatus?: (status: TxStatus) => void,
         cancelRequested?: () => boolean,
+        timeout?: number,
     ): SyncOrPromise<T> =>
         this.v1 && isV1Selector(selector)
             ? this.v1.waitForTX<T>(
@@ -158,12 +159,14 @@ export class CombinedProvider
                   utxoTxHash,
                   onStatus,
                   cancelRequested,
+                  timeout,
               )
             : this.v2.waitForTX<T>(
                   selector,
                   utxoTxHash,
                   onStatus,
                   cancelRequested,
+                  timeout,
               );
 
     /**

--- a/packages/lib/rpc/src/v1/renVMProvider.ts
+++ b/packages/lib/rpc/src/v1/renVMProvider.ts
@@ -18,6 +18,7 @@ import {
     assertType,
     extractError,
     fromBase64,
+    isDefined,
     keccak256,
     parseV1Selector,
     SECONDS,
@@ -388,6 +389,7 @@ export class RenVMProvider
         utxoTxHash: Buffer,
         onStatus?: (status: TxStatus) => void,
         _cancelRequested?: () => boolean,
+        timeout?: number,
     ): Promise<T> => {
         assertType<Buffer>("Buffer", { utxoTxHash });
         let rawResponse;
@@ -419,7 +421,7 @@ export class RenVMProvider
                     // TODO: throw unexpected errors
                 }
             }
-            await sleep(15 * SECONDS);
+            await sleep(isDefined(timeout) ? timeout : 15 * SECONDS);
         }
         return rawResponse;
     };

--- a/packages/lib/rpc/src/v2/renVMProvider.ts
+++ b/packages/lib/rpc/src/v2/renVMProvider.ts
@@ -15,6 +15,7 @@ import { HttpProvider, Provider } from "@renproject/provider";
 import {
     assertType,
     fromBase64,
+    isDefined,
     SECONDS,
     sleep,
     toURLBase64,
@@ -325,6 +326,7 @@ export class RenVMProvider
         utxoTxHash: Buffer,
         onStatus?: (status: TxStatus) => void,
         _cancelRequested?: () => boolean,
+        timeout?: number,
     ): Promise<T> => {
         assertType<Buffer>("Buffer", { utxoTxHash });
         let rawResponse: T;
@@ -356,7 +358,7 @@ export class RenVMProvider
                     // TODO: throw unexpected errors
                 }
             }
-            await sleep(15 * SECONDS);
+            await sleep(isDefined(timeout) ? timeout : 15 * SECONDS);
         }
         return rawResponse;
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9932,7 +9932,7 @@ ethereumjs-util@^6.0.0:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
-ethereumjs-util@^7.0.7:
+ethereumjs-util@^7.0.8:
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.8.tgz#5258762b7b17e3d828e41834948363ff0a703ffd"
   integrity sha512-JJt7tDpCAmDPw/sGoFYeq0guOVqT3pTE9xlEbBmc/nlCij3JRCoS2c96SQ6kXVHOT3xWUNLDm5QCJLQaUnVAtQ==


### PR DESCRIPTION
Currently, most repeated network requests use a common timeout of 15 seconds between requests.

This PR makes this timeout configurable. A future update may provide more granular configuration options to configure each type of network request timeout.