### PR TITLE
fix(ren-js): remove call to 'strip0x' in 'fromBase64

### DIFF
--- a/packages/lib/utils/src/common.ts
+++ b/packages/lib/utils/src/common.ts
@@ -55,9 +55,7 @@ export const fromBase64 = (base64: Buffer | string): Buffer => {
     assertType<Buffer | string>("Buffer | string", {
         base64,
     });
-    return Buffer.isBuffer(base64)
-        ? base64
-        : Buffer.from(strip0x(base64), "base64");
+    return Buffer.isBuffer(base64) ? base64 : Buffer.from(base64, "base64");
 };
 
 export const toBase64 = (input: Buffer): string => {


### PR DESCRIPTION
The 'fromBase64' util function had a call to strip0x that had accidentally been included after copying and modifying the function from 'fromHex'.