### PR TITLE
fix(multiwallet): Only allow BSC wallet for the BSC injected connector

### DIFF
--- a/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/src/index.ts
+++ b/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/src/index.ts
@@ -35,6 +35,6 @@ export class BinanceSmartChainInjectedConnector extends EthereumInjectedConnecto
     }
 
     getProvider = () => {
-        return (window.BinanceChain || window.ethereum) as InjectedProvider;
+        return window.BinanceChain as InjectedProvider;
     };
 }


### PR DESCRIPTION
Metamask should be used as a separate connector, as it has its own
settings that need to be entered by the user