### PR TITLE
feat(multiwallet): return to wallet selection state from connection info state

### DIFF
--- a/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/src/index.ts
+++ b/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/src/index.ts
@@ -28,6 +28,12 @@ export class EthereumMEWConnectConnector extends AbstractEthereumConnector<MewPr
     constructor(options: EthereumConnectorOptions) {
         super(options);
         this.chainId = options.chainId;
+        for (let rpc of Object.values(options.rpc)) {
+            console.log(rpc);
+            if (rpc[0] !== "w") {
+                throw new Error("rpc must be websocket (wss://)");
+            }
+        }
         this.rpc = options.rpc;
     }
     handleUpdate = () => {
@@ -102,9 +108,9 @@ export class EthereumMEWConnectConnector extends AbstractEthereumConnector<MewPr
     // eslint-disable-next-line @typescript-eslint/require-await
     getRenNetwork = async (): Promise<RenNetwork> => {
         if (!this.provider) throw new Error("not initialized");
-        // MEWConnect only support Mainnet
-        return RenNetwork.Mainnet;
-        // return this.networkIdMapper(await this.provider.send("eth_chainId"));
+        return this.networkIdMapper(
+            await this.provider.send("eth_chainId", [])
+        );
     };
 
     async cleanup() {

--- a/packages/ui/multiwallet-ui/example/index.tsx
+++ b/packages/ui/multiwallet-ui/example/index.tsx
@@ -15,6 +15,8 @@ import {
   useMultiwallet,
 } from "../src/MultiwalletProvider";
 
+const INFURA_PROJECT_ID = process.env.REACT_APP_INFURA_PROJECT_ID;
+
 const options: WalletPickerConfig<unknown, string> = {
   chains: {
     ethereum: [
@@ -28,8 +30,8 @@ const options: WalletPickerConfig<unknown, string> = {
         logo: "https://avatars0.githubusercontent.com/u/37784886?s=60&v=4",
         connector: new EthereumWalletConnectConnector({
           rpc: {
-            1: `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
-            42: `https://kovan.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
+            1: `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
+            42: `https://kovan.infura.io/v3/${INFURA_PROJECT_ID}`,
           },
           qrcode: true,
           debug: true,
@@ -40,8 +42,8 @@ const options: WalletPickerConfig<unknown, string> = {
         logo: "https://avatars0.githubusercontent.com/u/24321658?s=60&v=4",
         connector: new EthereumMEWConnectConnector({
           rpc: {
-            1: `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
-            42: `wss://kovan.infura.io/ws/v3/${process.env.REACT_APP_INFURA_KEY}`,
+            1: `wss://mainnet.infura.io/ws/v3/${INFURA_PROJECT_ID}`,
+            42: `wss://kovan.infura.io/ws/v3/${INFURA_PROJECT_ID}`,
           },
           chainId: 42,
           debug: true,

--- a/packages/ui/multiwallet-ui/example/yarn.lock
+++ b/packages/ui/multiwallet-ui/example/yarn.lock
@@ -5086,10 +5086,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.4.5:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uncss@^0.17.3:
   version "0.17.3"

--- a/packages/ui/multiwallet-ui/src/index.tsx
+++ b/packages/ui/multiwallet-ui/src/index.tsx
@@ -33,7 +33,11 @@ export interface ConnectorConfig<P, A> {
   /**
    * A component to be shown before a wallet is activated, for extra context / warnings
    */
-  info?: React.FC<{ acknowledge: () => void; onClose: () => void }>;
+  info?: React.FC<{
+    acknowledge: () => void;
+    onClose: () => void;
+    onPrev: () => void;
+  }>;
 }
 
 export interface WalletPickerConfig<P, A> {
@@ -253,6 +257,7 @@ export const WalletPicker = <P, A>({
                   {...x}
                   classes={walletClasses}
                   onClose={onClose}
+                  onPrev={() => setInfo(undefined)}
                   chain={chain}
                   setInfo={setInfo}
                   WalletEntryButton={WalletEntryButton}
@@ -361,6 +366,7 @@ interface WalletEntryProps<P, A> extends ConnectorConfig<P, A> {
   chain: string;
   classes?: ReturnType<typeof useWalletEntryStyles>;
   onClose: () => void;
+  onPrev: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setInfo: (i: any) => void;
   WalletEntryButton?: WalletPickerProps<P, A>["WalletEntryButton"];
@@ -374,6 +380,7 @@ const WalletEntry = <P, A>({
   info: Info,
   classes,
   onClose,
+  onPrev,
   setInfo,
   WalletEntryButton,
 }: WalletEntryProps<P, A>): JSX.Element => {
@@ -384,6 +391,7 @@ const WalletEntry = <P, A>({
       return setInfo(() => (
         <InfoConstructor
           onClose={onClose}
+          onPrev={onPrev}
           acknowledge={() => {
             setInfo(undefined);
             activateConnector(chain, connector);

--- a/packages/ui/multiwallet-ui/stories/WalletPickerModal.stories.tsx
+++ b/packages/ui/multiwallet-ui/stories/WalletPickerModal.stories.tsx
@@ -70,11 +70,14 @@ const connectingProps: WalletPickerModalProps<any, any> = {
       chains: {
         ethereum: [
           {
-            info: ({ acknowledge, onClose }) => (
+            info: ({ acknowledge, onClose, onPrev }) => (
               <div>
+                <button onClick={onPrev}>back</button>
                 Are you sure you want to connect this wallet?{" "}
-                <button onClick={acknowledge}>Yes</button>
-                <button onClick={onClose}>No</button>
+                <div>
+                  <button onClick={acknowledge}>Yes</button>
+                  <button onClick={onClose}>No</button>
+                </div>
               </div>
             ),
             name: "metamask",


### PR DESCRIPTION
This PR allows for the modal to rever to the wallet selection state if the info prop is provided for a wallet, allowing users to select a different wallet based on clarified information.