### PR TITLE
feat(ren-js): allow updating chain provider

### DIFF
--- a/packages/lib/chains/chains-ethereum/src/base.ts
+++ b/packages/lib/chains/chains-ethereum/src/base.ts
@@ -144,7 +144,7 @@ export class EthereumBaseChain
         () => this.renNetworkDetails,
     );
 
-    public readonly web3: Web3 | undefined;
+    public web3: Web3 | undefined;
     public renNetworkDetails: EthereumConfig | undefined;
 
     public readonly getTokenContractAddress = async (asset: string) => {
@@ -188,6 +188,11 @@ export class EthereumBaseChain
             this.renNetworkDetails = resolveNetwork(renNetwork);
         }
     }
+
+    public withProvider = (web3Provider: provider) => {
+        this.web3 = new Web3(web3Provider);
+        return this;
+    };
 
     /**
      * See [LockChain.initialize].

--- a/packages/lib/interfaces/src/chain.ts
+++ b/packages/lib/interfaces/src/chain.ts
@@ -87,6 +87,8 @@ export interface ChainCommon<
         network: RenNetwork | RenNetworkString | RenNetworkDetails,
     ) => SyncOrPromise<this>;
 
+    withProvider?: (...args: any[]) => SyncOrPromise<this>;
+
     // Supported assets
 
     /**

--- a/packages/lib/ren/src/lockAndMint.ts
+++ b/packages/lib/ren/src/lockAndMint.ts
@@ -615,6 +615,7 @@ export class LockAndMintDeposit<
     /** See [[RenJS.renVM]]. */
     public renVM: AbstractRenVMProvider;
 
+    public mintTransaction?: MintTransaction;
     public revertReason?: string;
 
     /**
@@ -888,8 +889,8 @@ export class LockAndMintDeposit<
             }
 
             try {
-                const transactionFound = await this.findTransaction();
-                if (transactionFound) {
+                const transaction = await this.findTransaction();
+                if (transaction) {
                     return DepositStatus.Submitted;
                 }
             } catch (_error) {
@@ -1273,11 +1274,12 @@ export class LockAndMintDeposit<
                 : undefined;
 
         // Check if the signature has already been submitted
-        return await this.params.to.findTransaction(
+        this.mintTransaction = await this.params.to.findTransaction(
             this.params.asset,
             this._state.nHash,
             sigHash,
         );
+        return this.mintTransaction;
     };
 
     /**
@@ -1333,7 +1335,7 @@ export class LockAndMintDeposit<
 
             const asset = this.params.asset;
 
-            const result = await this.params.to.submitMint(
+            this.mintTransaction = await this.params.to.submitMint(
                 asset,
                 contractCalls,
                 this._state.queryTxResult,
@@ -1343,7 +1345,7 @@ export class LockAndMintDeposit<
             // Update status.
             this.status = DepositStatus.Submitted;
 
-            return result;
+            return this.mintTransaction;
         })()
             .then(promiEvent.resolve)
             .catch(promiEvent.reject);


### PR DESCRIPTION
Add `withProvider` for updating a chain's provider, and add `mintTransaction` to `LockAndMintDeposit`.

Using `withProvider` allows a website to initialize a LockAndMintDeposit or BurnAndRelease with a read-only provider and then switch to a provider with an unlocked account at the moment of needing to submit a transaction on the relevant chain.