### PR TITLE
Release 2.1.3

### DIFF
--- a/packages/lib/chains/chains-ethereum/src/base.ts
+++ b/packages/lib/chains/chains-ethereum/src/base.ts
@@ -144,7 +144,7 @@ export class EthereumBaseChain
         () => this.renNetworkDetails,
     );
 
-    public readonly web3: Web3 | undefined;
+    public web3: Web3 | undefined;
     public renNetworkDetails: EthereumConfig | undefined;
 
     public readonly getTokenContractAddress = async (asset: string) => {
@@ -188,6 +188,11 @@ export class EthereumBaseChain
             this.renNetworkDetails = resolveNetwork(renNetwork);
         }
     }
+
+    public withProvider = (web3Provider: provider) => {
+        this.web3 = new Web3(web3Provider);
+        return this;
+    };
 
     /**
      * See [LockChain.initialize].

--- a/packages/lib/interfaces/src/chain.ts
+++ b/packages/lib/interfaces/src/chain.ts
@@ -87,6 +87,8 @@ export interface ChainCommon<
         network: RenNetwork | RenNetworkString | RenNetworkDetails,
     ) => SyncOrPromise<this>;
 
+    withProvider?: (...args: any[]) => SyncOrPromise<this>;
+
     // Supported assets
 
     /**

--- a/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/src/index.ts
+++ b/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/src/index.ts
@@ -35,6 +35,6 @@ export class BinanceSmartChainInjectedConnector extends EthereumInjectedConnecto
     }
 
     getProvider = () => {
-        return (window.BinanceChain || window.ethereum) as InjectedProvider;
+        return window.BinanceChain as InjectedProvider;
     };
 }

--- a/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/README.md
+++ b/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/README.md
@@ -14,6 +14,8 @@ new EthereumMEWConnectConnector({
 });
 ```
 
+Note, must be served on an HTTPS connection in order to work, so local-host testing can be problematic.
+
 ### Parameters
 
 | parameter | type                | description                                        |

--- a/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/src/index.ts
+++ b/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/src/index.ts
@@ -28,6 +28,12 @@ export class EthereumMEWConnectConnector extends AbstractEthereumConnector<MewPr
     constructor(options: EthereumConnectorOptions) {
         super(options);
         this.chainId = options.chainId;
+        for (let rpc of Object.values(options.rpc)) {
+            console.log(rpc);
+            if (rpc[0] !== "w") {
+                throw new Error("rpc must be websocket (wss://)");
+            }
+        }
         this.rpc = options.rpc;
     }
     handleUpdate = () => {
@@ -102,9 +108,9 @@ export class EthereumMEWConnectConnector extends AbstractEthereumConnector<MewPr
     // eslint-disable-next-line @typescript-eslint/require-await
     getRenNetwork = async (): Promise<RenNetwork> => {
         if (!this.provider) throw new Error("not initialized");
-        // MEWConnect only support Mainnet
-        return RenNetwork.Mainnet;
-        // return this.networkIdMapper(await this.provider.send("eth_chainId"));
+        return this.networkIdMapper(
+            await this.provider.send("eth_chainId", [])
+        );
     };
 
     async cleanup() {

--- a/packages/lib/ren/src/lockAndMint.ts
+++ b/packages/lib/ren/src/lockAndMint.ts
@@ -615,6 +615,7 @@ export class LockAndMintDeposit<
     /** See [[RenJS.renVM]]. */
     public renVM: AbstractRenVMProvider;
 
+    public mintTransaction?: MintTransaction;
     public revertReason?: string;
 
     /**
@@ -888,8 +889,8 @@ export class LockAndMintDeposit<
             }
 
             try {
-                const transactionFound = await this.findTransaction();
-                if (transactionFound) {
+                const transaction = await this.findTransaction();
+                if (transaction) {
                     return DepositStatus.Submitted;
                 }
             } catch (_error) {
@@ -1273,11 +1274,12 @@ export class LockAndMintDeposit<
                 : undefined;
 
         // Check if the signature has already been submitted
-        return await this.params.to.findTransaction(
+        this.mintTransaction = await this.params.to.findTransaction(
             this.params.asset,
             this._state.nHash,
             sigHash,
         );
+        return this.mintTransaction;
     };
 
     /**
@@ -1333,7 +1335,7 @@ export class LockAndMintDeposit<
 
             const asset = this.params.asset;
 
-            const result = await this.params.to.submitMint(
+            this.mintTransaction = await this.params.to.submitMint(
                 asset,
                 contractCalls,
                 this._state.queryTxResult,
@@ -1343,7 +1345,7 @@ export class LockAndMintDeposit<
             // Update status.
             this.status = DepositStatus.Submitted;
 
-            return result;
+            return this.mintTransaction;
         })()
             .then(promiEvent.resolve)
             .catch(promiEvent.reject);

--- a/packages/ui/multiwallet-ui/example/index.tsx
+++ b/packages/ui/multiwallet-ui/example/index.tsx
@@ -15,6 +15,8 @@ import {
   useMultiwallet,
 } from "../src/MultiwalletProvider";
 
+const INFURA_PROJECT_ID = process.env.REACT_APP_INFURA_PROJECT_ID;
+
 const options: WalletPickerConfig<unknown, string> = {
   chains: {
     ethereum: [
@@ -28,8 +30,8 @@ const options: WalletPickerConfig<unknown, string> = {
         logo: "https://avatars0.githubusercontent.com/u/37784886?s=60&v=4",
         connector: new EthereumWalletConnectConnector({
           rpc: {
-            1: `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
-            42: `https://kovan.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
+            1: `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
+            42: `https://kovan.infura.io/v3/${INFURA_PROJECT_ID}`,
           },
           qrcode: true,
           debug: true,
@@ -40,8 +42,8 @@ const options: WalletPickerConfig<unknown, string> = {
         logo: "https://avatars0.githubusercontent.com/u/24321658?s=60&v=4",
         connector: new EthereumMEWConnectConnector({
           rpc: {
-            1: `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_KEY}`,
-            42: `wss://kovan.infura.io/ws/v3/${process.env.REACT_APP_INFURA_KEY}`,
+            1: `wss://mainnet.infura.io/ws/v3/${INFURA_PROJECT_ID}`,
+            42: `wss://kovan.infura.io/ws/v3/${INFURA_PROJECT_ID}`,
           },
           chainId: 42,
           debug: true,

--- a/packages/ui/multiwallet-ui/example/yarn.lock
+++ b/packages/ui/multiwallet-ui/example/yarn.lock
@@ -5086,10 +5086,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.4.5:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uncss@^0.17.3:
   version "0.17.3"

--- a/packages/ui/multiwallet-ui/src/index.tsx
+++ b/packages/ui/multiwallet-ui/src/index.tsx
@@ -33,7 +33,11 @@ export interface ConnectorConfig<P, A> {
   /**
    * A component to be shown before a wallet is activated, for extra context / warnings
    */
-  info?: React.FC<{ acknowledge: () => void; onClose: () => void }>;
+  info?: React.FC<{
+    acknowledge: () => void;
+    onClose: () => void;
+    onPrev: () => void;
+  }>;
 }
 
 export interface WalletPickerConfig<P, A> {
@@ -253,6 +257,7 @@ export const WalletPicker = <P, A>({
                   {...x}
                   classes={walletClasses}
                   onClose={onClose}
+                  onPrev={() => setInfo(undefined)}
                   chain={chain}
                   setInfo={setInfo}
                   WalletEntryButton={WalletEntryButton}
@@ -361,6 +366,7 @@ interface WalletEntryProps<P, A> extends ConnectorConfig<P, A> {
   chain: string;
   classes?: ReturnType<typeof useWalletEntryStyles>;
   onClose: () => void;
+  onPrev: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setInfo: (i: any) => void;
   WalletEntryButton?: WalletPickerProps<P, A>["WalletEntryButton"];
@@ -374,6 +380,7 @@ const WalletEntry = <P, A>({
   info: Info,
   classes,
   onClose,
+  onPrev,
   setInfo,
   WalletEntryButton,
 }: WalletEntryProps<P, A>): JSX.Element => {
@@ -384,6 +391,7 @@ const WalletEntry = <P, A>({
       return setInfo(() => (
         <InfoConstructor
           onClose={onClose}
+          onPrev={onPrev}
           acknowledge={() => {
             setInfo(undefined);
             activateConnector(chain, connector);

--- a/packages/ui/multiwallet-ui/stories/WalletPickerModal.stories.tsx
+++ b/packages/ui/multiwallet-ui/stories/WalletPickerModal.stories.tsx
@@ -70,11 +70,14 @@ const connectingProps: WalletPickerModalProps<any, any> = {
       chains: {
         ethereum: [
           {
-            info: ({ acknowledge, onClose }) => (
+            info: ({ acknowledge, onClose, onPrev }) => (
               <div>
+                <button onClick={onPrev}>back</button>
                 Are you sure you want to connect this wallet?{" "}
-                <button onClick={acknowledge}>Yes</button>
-                <button onClick={onClose}>No</button>
+                <div>
+                  <button onClick={acknowledge}>Yes</button>
+                  <button onClick={onClose}>No</button>
+                </div>
               </div>
             ),
             name: "metamask",


### PR DESCRIPTION
2.1.3 includes the following updates:

1) The BSC injected connector no longer uses `window.ethereum` as a fallback
2) Update the mewconnect connector with testnet support
3) Add `withProvider` to the ren-js chains interface (for switching from a read-only provider to an unlocked provider)