### PR TITLE
feat(ren-js): update LUNA support

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.1.3"
+    "version": "2.1.4"
 }

--- a/packages/lib/chains/chains-filecoin/package.json
+++ b/packages/lib/chains/chains-filecoin/package.json
@@ -51,6 +51,7 @@
         "@types/elliptic": "^6.4.12",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
+        "blakejs": "^1.1.0",
         "cids": "^1.1.5",
         "elliptic": "^6.5.3"
     },

--- a/packages/lib/chains/chains-filecoin/package.json
+++ b/packages/lib/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/lib/chains/chains-terra/package.json
+++ b/packages/lib/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -46,10 +46,10 @@
         "@renproject/rpc": "^2.1.3",
         "@renproject/utils": "^2.1.3",
         "@terra-money/terra.js": "1.3.6",
+        "@types/elliptic": "^6.4.12",
         "@types/node": ">=10",
         "bech32": "^1.1.4",
         "bignumber.js": "^9.0.1",
-        "@types/elliptic": "^6.4.12",
         "blakejs": "^1.1.0",
         "elliptic": "^6.5.3"
     },

--- a/packages/lib/chains/chains-terra/package.json
+++ b/packages/lib/chains/chains-terra/package.json
@@ -48,7 +48,10 @@
         "@terra-money/terra.js": "1.3.6",
         "@types/node": ">=10",
         "bech32": "^1.1.4",
-        "bignumber.js": "^9.0.1"
+        "bignumber.js": "^9.0.1",
+        "@types/elliptic": "^6.4.12",
+        "blakejs": "^1.1.0",
+        "elliptic": "^6.5.3"
     },
     "resolutions": {
         "sha3": "^2.1.2"

--- a/packages/lib/chains/chains-terra/src/api/deposit.ts
+++ b/packages/lib/chains/chains-terra/src/api/deposit.ts
@@ -18,7 +18,7 @@ export interface TerraAPI {
     fetchDeposits: (
         address: string,
         network: TerraNetwork,
-        memo: string | undefined,
+        memo?: string | undefined,
         page?: number,
     ) => Promise<TerraTransaction[]>;
 
@@ -32,8 +32,8 @@ export interface TerraAPI {
 export type TerraAddress = {
     address: string; // Terra address
     asset?: string; // Asset tied to the pHash in the memo.
-    memo?: string; // Base64 string of the pHash.
 };
+
 export type TerraDeposit = {
     transaction: TerraTransaction;
     amount: string;

--- a/packages/lib/chains/chains-terra/src/api/stakeId.ts
+++ b/packages/lib/chains/chains-terra/src/api/stakeId.ts
@@ -164,7 +164,8 @@ const fetchDeposits = async (
     const chainHeight = filteredTxs.length > 0 ? await getHeight(network) : 0;
     return filteredTxs
         .map(extractDepositsFromTx(chainHeight))
-        .reduce(concat, []);
+        .reduce(concat, [])
+        .filter((msg) => msg.to === address);
 };
 
 const fetchDeposit = async (

--- a/packages/lib/chains/chains-terra/src/api/terraDev.ts
+++ b/packages/lib/chains/chains-terra/src/api/terraDev.ts
@@ -235,7 +235,8 @@ const fetchDeposits = async (
     const chainHeight = filteredTxs.length > 0 ? await getHeight(network) : 0;
     return filteredTxs
         .map(extractDepositsFromTx(chainHeight))
-        .reduce(concat, []);
+        .reduce(concat, [])
+        .filter((msg) => msg.to === address);
 };
 
 const fetchDeposit = async (

--- a/packages/lib/chains/chains-terra/src/types/declarations.ts
+++ b/packages/lib/chains/chains-terra/src/types/declarations.ts
@@ -1,4 +1,3 @@
 declare module "@openworklabs/filecoin-address";
 declare module "@openworklabs/filecoin-address/dist/base32";
-declare module "elliptic";
 declare module "blakejs";

--- a/packages/lib/chains/chains/package.json
+++ b/packages/lib/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,8 +45,8 @@
     "dependencies": {
         "@renproject/chains-bitcoin": "^2.1.3",
         "@renproject/chains-ethereum": "^2.1.3",
-        "@renproject/chains-filecoin": "^2.1.3",
-        "@renproject/chains-terra": "^2.1.3",
+        "@renproject/chains-filecoin": "^2.1.4",
+        "@renproject/chains-terra": "^2.1.4",
         "@renproject/interfaces": "^2.1.3",
         "@types/node": ">=10"
     },

--- a/packages/lib/chains/chains/src/declarations/declarations.d.ts
+++ b/packages/lib/chains/chains/src/declarations/declarations.d.ts
@@ -1,6 +1,5 @@
 declare module "wallet-address-validator";
 declare module "bitcore-lib/lib/encoding/base58check";
 declare module "bitcore-lib-zcash/lib/encoding/base58check";
-declare module "elliptic";
 declare module "blakejs";
 declare module "@glif/filecoin-address";

--- a/packages/lib/test/package.json
+++ b/packages/lib/test/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test",
     "private": true,
-    "version": "2.1.3",
+    "version": "2.1.4",
     "scripts": {
         "describe": "npm-scripts-info",
         "prettier": "yarn fix:prettier",
@@ -24,8 +24,8 @@
         "build:module": "tsc -p tsconfig.module.json"
     },
     "dependencies": {
-        "@renproject/chains": "^2.1.3",
-        "@renproject/chains-terra": "^2.1.3",
+        "@renproject/chains": "^2.1.4",
+        "@renproject/chains-terra": "^2.1.4",
         "@renproject/interfaces": "^2.1.3",
         "@renproject/provider": "^2.1.3",
         "@renproject/ren": "^2.1.3",


### PR DESCRIPTION
This PR updates LUNA support to encode the ghash in the deposit address instead of a memo field.