### PR TITLE
fix(chains): testnetv0.3 has migrated to kovan

### DIFF
--- a/packages/lib/chains/chains-ethereum/src/networks.ts
+++ b/packages/lib/chains/chains-ethereum/src/networks.ts
@@ -59,7 +59,7 @@ export const renTestnet: EthereumConfig = {
 
 export const renDevnetVDot3: EthereumConfig = {
     name: "Devnet v0.3",
-    ...ethereumConfig.rinkeby,
+    ...ethereumConfig.kovan,
     addresses: {
         GatewayRegistry: "0x1CAD87e16b56815d6a0b4Cd91A6639eae86Fc53A",
         BasicAdapter: "0xC8DD18A151FafFCab1B822108e49b4aE3bFff477",
@@ -68,10 +68,10 @@ export const renDevnetVDot3: EthereumConfig = {
 
 export const renTestnetVDot3: EthereumConfig = {
     name: "Testnet v0.3",
-    ...ethereumConfig.rinkeby,
+    ...ethereumConfig.kovan,
     addresses: {
-        GatewayRegistry: "0xcF9F36668ad5b28B336B248a67268AFcF1ECbdbF",
-        BasicAdapter: "0x6fA045D176CE69Fdf9837242E8A72e81c2750E64",
+        GatewayRegistry: "0x557e211EC5fc9a6737d2C6b7a1aDe3e0C11A8D5D",
+        BasicAdapter: "0x7DDFA2e5435027f6e13Ca8Db2f32ebd5551158Bb",
     },
 };
 

--- a/packages/lib/chains/chains-ethereum/src/networks.ts
+++ b/packages/lib/chains/chains-ethereum/src/networks.ts
@@ -61,8 +61,8 @@ export const renDevnetVDot3: EthereumConfig = {
     name: "Devnet v0.3",
     ...ethereumConfig.kovan,
     addresses: {
-        GatewayRegistry: "0x1CAD87e16b56815d6a0b4Cd91A6639eae86Fc53A",
-        BasicAdapter: "0xC8DD18A151FafFCab1B822108e49b4aE3bFff477",
+        GatewayRegistry: "0x5045E727D9D9AcDe1F6DCae52B078EC30dC95455",
+        BasicAdapter: "0xFABDB1F53Ef8B080332621cBc9F820a39e7A1B83",
     },
 };
 


### PR DESCRIPTION
This PR fixes the configuration for Ethereum so that we can mint/burn Dogecoin on Kovan