### PR TITLE
feat(ren-js): allow loading completed txes

### DIFF
--- a/packages/lib/ren-tx/src/configs/genericMint.ts
+++ b/packages/lib/ren-tx/src/configs/genericMint.ts
@@ -341,7 +341,7 @@ const mintFlow = (
                   sourceTxConfs:
                       0 || parseInt(rawSourceTx.transaction.confirmations),
                   rawSourceTx,
-                  destTxHash: deposit.mintTransaction,
+                  destTxHash: deposit?.mintTransaction,
                   detectedAt: new Date().getTime(),
               };
 

--- a/packages/lib/ren/src/config.ts
+++ b/packages/lib/ren/src/config.ts
@@ -17,4 +17,12 @@ export interface RenJSConfig {
      * It defaults to `15000` (15 seconds).
      */
     networkDelay?: number;
+
+    /**
+     * `loadCompletedDeposits` whether or not to detect deposits that have
+     * already been minted.
+     *
+     * It defaults to false
+     */
+    loadCompletedDeposits?: boolean;
 }

--- a/packages/lib/ren/src/lockAndMint.ts
+++ b/packages/lib/ren/src/lockAndMint.ts
@@ -39,6 +39,7 @@ import {
 } from "@renproject/utils";
 import { EventEmitter } from "events";
 import { OrderedMap } from "immutable";
+import { config } from "process";
 import { AbiCoder } from "web3-eth-abi";
 import { RenJSConfig } from "./config";
 
@@ -366,7 +367,10 @@ export class LockAndMint<
             await depositObject._initialize();
 
             // Check if deposit has already been submitted.
-            if (depositObject.status !== DepositStatus.Submitted) {
+            if (
+                this._state.config.loadCompletedDeposits ||
+                depositObject.status !== DepositStatus.Submitted
+            ) {
                 this.emit("deposit", depositObject);
                 // this.deposits.set(deposit);
                 this._state.logger.debug("new deposit:", deposit);


### PR DESCRIPTION
There are some cases where we may want to fetch deposits that
have already been minted.

This implements that by passing a "loadCompletedDeposits" flag in
the RenJS config object, which will cause all completed deposits to
still trigger the .deposit handler.

The PR also updates ren-tx to handle completed deposits