### PR TITLE
Bech32 fix in Bitcoin.addressStringToBytes

### DIFF
--- a/packages/lib/chains/chains-bitcoin/src/base.ts
+++ b/packages/lib/chains/chains-bitcoin/src/base.ts
@@ -1,3 +1,4 @@
+import bech32 from "bech32";
 import {
     getRenNetworkDetails,
     LockChain,
@@ -264,7 +265,17 @@ export abstract class BitcoinBaseChain
      * See [[LockChain.addressStringToBytes]].
      */
     addressStringToBytes = (address: string): Buffer => {
-        return base58.decode(address);
+        try {
+            return base58.decode(address);
+        } catch (error) {
+            try {
+                return Buffer.from(
+                    bech32.fromWords(bech32.decode(address).words.slice(1)),
+                );
+            } catch (internalError) {
+                throw new Error(`Unrecognized address format "${address}".`);
+            }
+        }
     };
 
     /**

--- a/packages/lib/chains/chains-bitcoin/src/digibyte.ts
+++ b/packages/lib/chains/chains-bitcoin/src/digibyte.ts
@@ -29,7 +29,7 @@ export class DigiByteClass extends BitcoinClass {
             case "testnet":
                 // prettier-ignore
                 return this
-                    .withAPI(Insight("https://testnet.digiexplorer.info/api"));
+                    .withAPI(Insight("https://testnetexplorer.digibyteservers.io/api"));
             case "regtest":
                 throw new Error(`Regtest is currently not supported.`);
         }
@@ -73,7 +73,7 @@ export class DigiByteClass extends BitcoinClass {
                 case "mainnet":
                     return `https://digiexplorer.info/address/${address}`;
                 case "testnet":
-                    return `https://testnet.digiexplorer.info/address/${address}`;
+                    return `https://testnetexplorer.digibyteservers.io/address/${address}`;
                 case "regtest":
                     return undefined;
             }
@@ -93,7 +93,7 @@ export class DigiByteClass extends BitcoinClass {
                 case "mainnet":
                     return `https://digiexplorer.info/tx/${txHash}`;
                 case "testnet":
-                    return `https://testnet.digiexplorer.info/tx/${txHash}`;
+                    return `https://testnetexplorer.digibyteservers.io/tx/${txHash}`;
                 case "regtest":
                     return undefined;
             }

--- a/packages/lib/chains/chains-bitcoin/test/addressValidation.spec.ts
+++ b/packages/lib/chains/chains-bitcoin/test/addressValidation.spec.ts
@@ -40,7 +40,7 @@ const testcases = [
     },
 ];
 
-describe.only("Address validation", () => {
+describe("Address validation", () => {
     for (const testcase of testcases) {
         for (const network of Object.keys(testcase.addresses)) {
             it(`${testcase.chain.asset} - ${network}`, async () => {

--- a/packages/lib/ren/src/burnAndRelease.ts
+++ b/packages/lib/ren/src/burnAndRelease.ts
@@ -229,7 +229,7 @@ export class BurnAndRelease<
                 2,
             );
         }
-        this._state.targetConfirmations = target || 6;
+        this._state.targetConfirmations = isDefined(target) ? target : 6;
 
         return this._state.targetConfirmations;
     };

--- a/packages/lib/ren/src/index.ts
+++ b/packages/lib/ren/src/index.ts
@@ -150,6 +150,7 @@ export default class RenJS {
             (providerOrNetwork as AbstractRenVMProvider).sendMessage
                 ? (providerOrNetwork as AbstractRenVMProvider)
                 : new CombinedProvider(
+                      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                       (providerOrNetwork || RenNetwork.Mainnet) as
                           | RenNetwork
                           | RenNetworkString

--- a/packages/lib/ren/src/index.ts
+++ b/packages/lib/ren/src/index.ts
@@ -7,6 +7,7 @@ import {
     LogLevel,
     MintChain,
     RenNetwork,
+    RenNetworkDetails,
     RenNetworkString,
     SimpleLogger,
 } from "@renproject/interfaces";
@@ -117,6 +118,7 @@ export default class RenJS {
         providerOrNetwork?:
             | RenNetwork
             | RenNetworkString
+            | RenNetworkDetails
             | AbstractRenVMProvider
             | null
             | undefined,
@@ -143,10 +145,15 @@ export default class RenJS {
 
         // Use provided provider, provider URL or default lightnode URL.
         this.renVM =
-            providerOrNetwork && typeof providerOrNetwork !== "string"
-                ? providerOrNetwork
+            providerOrNetwork &&
+            typeof providerOrNetwork !== "string" &&
+            (providerOrNetwork as AbstractRenVMProvider).sendMessage
+                ? (providerOrNetwork as AbstractRenVMProvider)
                 : new CombinedProvider(
-                      providerOrNetwork || RenNetwork.Mainnet,
+                      (providerOrNetwork || RenNetwork.Mainnet) as
+                          | RenNetwork
+                          | RenNetworkString
+                          | RenNetworkDetails,
                       this._logger,
                   );
     }

--- a/packages/lib/ren/src/lockAndMint.ts
+++ b/packages/lib/ren/src/lockAndMint.ts
@@ -229,7 +229,9 @@ export class LockAndMint<
         }
         const defaultConfirmations =
             this._state.renNetwork && this._state.renNetwork.isTestnet ? 2 : 6;
-        this._state.targetConfirmations = target || defaultConfirmations;
+        this._state.targetConfirmations = isDefined(target)
+            ? target
+            : defaultConfirmations;
 
         return this._state.targetConfirmations;
     };


### PR DESCRIPTION
This PR includes:

1) a fix when decoding bech32 addresses
2) a fix for when the confirmation target is 0
3) an updated testnet explorer link for DGB