### PR TITLE
fix(ren js): don't skip fetching signature even if already submitted

### DIFF
--- a/packages/lib/ren/src/lockAndMint.ts
+++ b/packages/lib/ren/src/lockAndMint.ts
@@ -1157,16 +1157,21 @@ export class LockAndMintDeposit<
         (async () => {
             let txHash = this.txHash();
 
+            // If the transaction has been reverted, throw the revert reason.
+            if (this.status === DepositStatus.Reverted) {
+                throw new Error(
+                    this.revertReason ||
+                        `RenVM transaction ${txHash} reverted.`,
+                );
+            }
+
+            // Check if the signature is already available.
             if (
                 DepositStatusIndex[this.status] >=
-                DepositStatusIndex[DepositStatus.Signed]
+                    DepositStatusIndex[DepositStatus.Signed] &&
+                this._state.queryTxResult &&
+                this._state.queryTxResult.out
             ) {
-                if (this.status === DepositStatus.Reverted) {
-                    throw new Error(
-                        this.revertReason ||
-                            `RenVM transaction ${txHash} reverted.`,
-                    );
-                }
                 return this;
             }
 


### PR DESCRIPTION
Currently, RenJS's lockAndMint.signed will skip fetching the signature if it has already been submitted to the mint-chain. This is problematic if the client needs to access the signature or assumes that it will be present.