### PR TITLE
feat(ren-tx): enter rejected state when tx is reverted

### DIFF
--- a/packages/lib/ren-tx/src/configs/genericMint.ts
+++ b/packages/lib/ren-tx/src/configs/genericMint.ts
@@ -221,15 +221,20 @@ const handleSign = async (
             return;
         }
         if (
-            v._state.queryTxResult.out &&
-            v._state.queryTxResult.out.revert !== undefined
+            (v._state.queryTxResult.out &&
+                v._state.queryTxResult.out.revert !== undefined) ||
+            v.revertReason
         ) {
+            deposit.revertReason;
             callback({
                 type: "REVERTED",
                 data: {
                     sourceTxHash,
                 },
-                error: v._state.queryTxResult.out.revert.toString(),
+                error:
+                    v._state.queryTxResult.out.revert?.toString() ||
+                    v.revertReason ||
+                    "",
             });
             return;
         } else {
@@ -246,16 +251,13 @@ const handleSign = async (
         }
     } catch (e) {
         // If error was due to revert - enter reverted state
-        if (
-            deposit._state?.queryTxResult?.out &&
-            deposit._state.queryTxResult.out.revert !== undefined
-        ) {
+        if (deposit.revertReason) {
             callback({
                 type: "REVERTED",
                 data: {
                     sourceTxHash,
                 },
-                error: deposit._state.queryTxResult.out.revert.toString(),
+                error: deposit.revertReason,
             });
             return;
         }

--- a/packages/lib/ren-tx/src/machines/mint.ts
+++ b/packages/lib/ren-tx/src/machines/mint.ts
@@ -229,6 +229,7 @@ export const mintMachine = Machine<
                 CONFIRMED: { actions: "routeEvent" },
                 ERROR: { actions: "routeEvent" },
                 SIGN_ERROR: { actions: "routeEvent" },
+                REVERTED: { actions: "routeEvent" },
                 SUBMIT_ERROR: { actions: "routeEvent" },
                 SIGNED: { actions: "routeEvent" },
                 SUBMITTED: { actions: "routeEvent" },

--- a/packages/lib/ren-tx/test/machines.spec.ts
+++ b/packages/lib/ren-tx/test/machines.spec.ts
@@ -78,6 +78,9 @@ const mintModel = createModel(mintMachine).withEvents({
     RESTORED: {
         cases: [{ data: { sourceTxHash: "123" } }],
     },
+    REVERTED: {
+        cases: [{ data: { sourceTxHash: "123" } }],
+    },
     EXPIRED: {},
     LISTENING: {},
     CLAIMABLE: {
@@ -128,10 +131,10 @@ const depositModel = createModel(
         cases: [{ error: new Error("error") }],
     },
     SIGN_ERROR: {
-        cases: [{ data: { message: "an error" } }],
+        cases: [{ error: { message: "an error" } }],
     },
     SUBMIT_ERROR: {
-        cases: [{ data: { message: "an error" } }],
+        cases: [{ error: { message: "an error" } }],
     },
     RESTORED: {
         cases: [{ data: { sourceTxHash: "123" } }],


### PR DESCRIPTION
Currently, we enter the "errorAccepting" state when a transaction cannot be signed.

This is probematic, because some errors can be recovered from, while others cannot.

This PR makes the deposit machine transition into the permanent "rejected" state if a revert is detected, and we can inform users that they should not attempt to retry.