### PR TITLE
fix(chains-bitcoin): add digibyte endpoint

### DIFF
--- a/packages/lib/chains/chains-bitcoin/src/digibyte.ts
+++ b/packages/lib/chains/chains-bitcoin/src/digibyte.ts
@@ -24,6 +24,7 @@ export class DigiByteClass extends BitcoinClass {
             case "mainnet":
                 // prettier-ignore
                 return this
+                    .withAPI(Insight("https://multichain-web-proxy.herokuapp.com/digibyte-mainnet"))
                     .withAPI(Insight("https://digiexplorer.info/api"))
                     .withAPI(Insight("https://insight.digibyte.host/api"))
             case "testnet":


### PR DESCRIPTION
One of the digibyte endpoints can no longer be accessed through a browser, so this adds an endpoint to access it through a proxy that also enables CORS.

Note that this means that rate limits may be hit sooner, so we may need to look into spinning up an electrumx node for DigiByte.