### PR TITLE
feat: fetch fees from lightnode instead of host-chain

### DIFF
--- a/packages/lib/ren/src/index.ts
+++ b/packages/lib/ren/src/index.ts
@@ -185,43 +185,16 @@ export default class RenJS {
             throw new Error(`Asset not supported by chain ${to.name}.`);
         }
 
-        let fees;
-
         if (await from.assetIsNative(asset)) {
             // LockAndMint
-            const mintFees = await (to as MintChain).getFees(asset);
-            const selector = this.renVM.selector({ asset, from, to });
-            const lockFees = await this.renVM.estimateTransactionFee(
-                selector,
-                from,
-            );
-            fees = {
-                ...lockFees,
-                ...mintFees,
-            };
+            return await this.renVM.estimateTransactionFee(asset, from, to);
         } else if (await to.assetIsNative(asset)) {
             // BurnAndRelease
-            const mintFees = await (from as MintChain).getFees(asset);
-            const selector = this.renVM.selector({ asset, from, to });
-            const lockFees = await this.renVM.estimateTransactionFee(
-                selector,
-                to,
-            );
-            fees = {
-                ...lockFees,
-                ...mintFees,
-            };
+            return await this.renVM.estimateTransactionFee(asset, to, from);
         } else {
             // BurnAndMint
-            const mintFees = await (from as MintChain).getFees(asset);
-            const burnFees = await (to as MintChain).getFees(asset);
-            fees = {
-                mint: mintFees.mint,
-                burn: burnFees.burn,
-            };
+            return await this.renVM.estimateTransactionFee(asset, from, to);
         }
-
-        return fees;
     };
 
     /**

--- a/packages/lib/rpc/src/abstract.ts
+++ b/packages/lib/rpc/src/abstract.ts
@@ -171,7 +171,13 @@ export interface AbstractRenVMProvider<
      * Return the estimated fee RenVM will use for locking and releasing.
      */
     estimateTransactionFee: (
-        selector: string,
-        chain: { name: string; legacyName?: string },
-    ) => SyncOrPromise<{ lock: BigNumber; release: BigNumber }>;
+        asset: string,
+        lockChain: { name: string; legacyName?: string },
+        hostChain: { name: string; legacyName?: string },
+    ) => SyncOrPromise<{
+        lock: BigNumber;
+        release: BigNumber;
+        mint: number;
+        burn: number;
+    }>;
 }

--- a/packages/lib/rpc/src/combinedProvider.ts
+++ b/packages/lib/rpc/src/combinedProvider.ts
@@ -203,10 +203,13 @@ export class CombinedProvider
             : this.v2.getConfirmationTarget(selector, chain);
 
     public estimateTransactionFee = async (
-        selector: string,
-        chain: { name: string },
-    ): Promise<{ lock: BigNumber; release: BigNumber }> =>
-        this.v1 && isV1Selector(selector)
-            ? this.v1.estimateTransactionFee(selector, chain)
-            : this.v2.estimateTransactionFee(selector, chain);
+        asset: string,
+        lockChain: { name: string },
+        hostChain: { name: string },
+    ): Promise<{
+        lock: BigNumber;
+        release: BigNumber;
+        mint: number;
+        burn: number;
+    }> => this.v2.estimateTransactionFee(asset, lockChain, hostChain);
 }

--- a/packages/lib/rpc/src/v1/renVMProvider.ts
+++ b/packages/lib/rpc/src/v1/renVMProvider.ts
@@ -511,14 +511,27 @@ export class RenVMProvider
     };
 
     public estimateTransactionFee = async (
-        _selector: string,
-        chain: { name: string; legacyName?: string },
-    ): Promise<{ lock: BigNumber; release: BigNumber }> => {
-        const fees = await this.getFees();
-        return fees[
-            chain.legacyName
-                ? chain.legacyName.toLowerCase()
-                : chain.name.toLowerCase()
-        ];
+        _asset: string,
+        _lockChain: { name: string; legacyName?: string },
+        hostChain: { name: string; legacyName?: string },
+    ): Promise<{
+        lock: BigNumber;
+        release: BigNumber;
+        mint: number;
+        burn: number;
+    }> => {
+        const allFees = await this.getFees();
+        const fees =
+            allFees[
+                hostChain.legacyName
+                    ? hostChain.legacyName.toLowerCase()
+                    : hostChain.name.toLowerCase()
+            ];
+
+        return {
+            ...fees,
+            mint: 25,
+            burn: 15,
+        };
     };
 }

--- a/packages/lib/rpc/src/v2/methods.ts
+++ b/packages/lib/rpc/src/v2/methods.ts
@@ -1,4 +1,8 @@
 import { TxStatus } from "@renproject/interfaces";
+import {
+    ParamsQueryBlockState,
+    ResponseQueryBlockState,
+} from "./methods/ren_queryBlockState";
 
 import { TypedPackValue } from "./pack/pack";
 import {
@@ -36,6 +40,9 @@ export enum RPCMethod {
 
     // MethodQueryState returns the contract state.
     QueryState = "ren_queryState",
+
+    // MethodQueryBlockState returns the contract state.
+    QueryBlockState = "ren_queryBlockState",
 }
 
 // Params //////////////////////////////////////////////////////////////////////
@@ -202,6 +209,7 @@ export type RenVMParams = {
     [RPCMethod.QueryBlocks]: ParamsQueryBlocks;
     [RPCMethod.QueryConfig]: ParamsQueryConfig;
     [RPCMethod.QueryState]: ParamsQueryState;
+    [RPCMethod.QueryBlockState]: ParamsQueryBlockState;
 };
 
 export type RenVMResponses = {
@@ -213,6 +221,7 @@ export type RenVMResponses = {
     [RPCMethod.QueryBlocks]: ResponseQueryBlocks;
     [RPCMethod.QueryConfig]: ResponseQueryConfig;
     [RPCMethod.QueryState]: ResponseQueryState;
+    [RPCMethod.QueryBlockState]: ResponseQueryBlockState;
 };
 
 // The following lines will throw a type error if RenVMResponses or RenVMParams

--- a/packages/lib/rpc/src/v2/methods/ren_queryBlockState.ts
+++ b/packages/lib/rpc/src/v2/methods/ren_queryBlockState.ts
@@ -1,0 +1,107 @@
+import {
+    Marshalled,
+    PackPrimitive,
+    TypedPackValue,
+    Unmarshalled,
+} from "../pack/pack";
+
+// ParamsQueryBlockState defines the parameters of the MethodQueryBlockState.
+export interface ParamsQueryBlockState {
+    // No parameters.
+}
+
+export interface ResponseQueryBlockState {
+    state: TypedPackValue<{
+        [asset: string]: {
+            latestHeight: Marshalled<PackPrimitive.U256>;
+            gasCap: Marshalled<PackPrimitive.U256>;
+            gasLimit: Marshalled<PackPrimitive.U256>;
+            gasPrice: Marshalled<PackPrimitive.U256>;
+            minimumAmount: Marshalled<PackPrimitive.U256>;
+            dustAmount: Marshalled<PackPrimitive.U256>;
+            fees: {
+                chains: Array<{
+                    burnFee: Marshalled<PackPrimitive.U64>;
+                    chain: Marshalled<PackPrimitive.Str>;
+                    mintFee: Marshalled<PackPrimitive.U64>;
+                }>;
+                epochs: Array<{
+                    amount: Marshalled<PackPrimitive.U256>;
+                    epoch: Marshalled<PackPrimitive.U64>;
+                    numNodes: Marshalled<PackPrimitive.U64>;
+                }>;
+                nodes: Array<{
+                    node: Marshalled<PackPrimitive.Bytes32>;
+                    lastEpochClaimed: Marshalled<PackPrimitive.U64>;
+                }>;
+                unassigned: Marshalled<PackPrimitive.U256>;
+            };
+            shards: Array<{
+                shard: Marshalled<PackPrimitive.Bytes32>;
+                pubKey: Marshalled<PackPrimitive.Bytes>;
+                queue: Array<{
+                    hash: Marshalled<PackPrimitive.Bytes32>;
+                }>;
+                state: {
+                    outpoint: {
+                        hash: Marshalled<PackPrimitive.Bytes>;
+                        index: Marshalled<PackPrimitive.U32>;
+                    };
+                    value: Marshalled<PackPrimitive.U256>;
+                    pubKeyScript: Marshalled<PackPrimitive.Bytes>;
+                };
+            }>;
+            minted: Array<{
+                chain: Marshalled<PackPrimitive.Str>;
+                amount: Marshalled<PackPrimitive.U256>;
+            }>;
+        };
+    }>;
+}
+
+export interface BlockState {
+    [asset: string]: {
+        latestHeight: Unmarshalled<PackPrimitive.U256>;
+        gasCap: Unmarshalled<PackPrimitive.U256>;
+        gasLimit: Unmarshalled<PackPrimitive.U256>;
+        gasPrice: Unmarshalled<PackPrimitive.U256>;
+        minimumAmount: Unmarshalled<PackPrimitive.U256>;
+        dustAmount: Unmarshalled<PackPrimitive.U256>;
+        fees: {
+            chains: Array<{
+                burnFee: Unmarshalled<PackPrimitive.U64>;
+                chain: Unmarshalled<PackPrimitive.Str>;
+                mintFee: Unmarshalled<PackPrimitive.U64>;
+            }>;
+            epochs: Array<{
+                amount: Unmarshalled<PackPrimitive.U256>;
+                epoch: Unmarshalled<PackPrimitive.U64>;
+                numNodes: Unmarshalled<PackPrimitive.U64>;
+            }>;
+            nodes: Array<{
+                node: Unmarshalled<PackPrimitive.Bytes32>;
+                lastEpochClaimed: Unmarshalled<PackPrimitive.U64>;
+            }>;
+            unassigned: Unmarshalled<PackPrimitive.U256>;
+        };
+        shards: Array<{
+            shard: Unmarshalled<PackPrimitive.Bytes32>;
+            pubKey: Unmarshalled<PackPrimitive.Bytes>;
+            queue: Array<{
+                hash: Unmarshalled<PackPrimitive.Bytes32>;
+            }>;
+            state: {
+                outpoint: {
+                    hash: Unmarshalled<PackPrimitive.Bytes>;
+                    index: Unmarshalled<PackPrimitive.U32>;
+                };
+                value: Unmarshalled<PackPrimitive.U256>;
+                pubKeyScript: Unmarshalled<PackPrimitive.Bytes>;
+            };
+        }>;
+        minted: Array<{
+            chain: Unmarshalled<PackPrimitive.Str>;
+            amount: Unmarshalled<PackPrimitive.U256>;
+        }>;
+    };
+}

--- a/packages/lib/test/test/refactor/burn.spec.ts
+++ b/packages/lib/test/test/refactor/burn.spec.ts
@@ -28,11 +28,11 @@ describe("Refactor - Burning", () => {
         this.timeout(100000000000);
 
         const network = RenNetwork.TestnetVDot3;
-        // const ethNetwork = EthereumConfigMap[network];
-        const ethNetwork = BscConfigMap[network];
+        const ethNetwork = EthereumConfigMap[network];
+        // const ethNetwork = BscConfigMap[network];
 
-        // const infuraURL = `${ethNetwork.infura}/v3/${process.env.INFURA_KEY}`; // renBscTestnet.infura
-        const infuraURL = ethNetwork.infura; // renBscTestnet.infura
+        const infuraURL = `${ethNetwork.infura}/v3/${process.env.INFURA_KEY}`; // renBscTestnet.infura
+        // const infuraURL = ethNetwork.infura; // renBscTestnet.infura
         const provider: provider = new HDWalletProvider({
             mnemonic: MNEMONIC || "",
             providerOrUrl: infuraURL,
@@ -46,7 +46,7 @@ describe("Refactor - Burning", () => {
         const recipient = await account.address(asset);
 
         const to = Chains.Bitcoin().Address(recipient);
-        const from = Chains.BinanceSmartChain(provider, network);
+        const from = Chains.Ethereum(provider, network);
         const fromAddress = (await from.web3.eth.getAccounts())[0];
 
         const logLevel = LogLevel.Log;

--- a/packages/lib/test/test/refactor/mint.spec.ts
+++ b/packages/lib/test/test/refactor/mint.spec.ts
@@ -39,8 +39,8 @@ describe("Refactor: mint", () => {
 
         const network = RenNetwork.Testnet;
         const ToClass = Chains.Ethereum;
-        const from = Chains.Zcash();
-        const asset = from.asset;
+        const from = Chains.Terra();
+        const asset = "LUNA"; // from.asset;
 
         const ethNetwork = ToClass.configMap[network];
 
@@ -96,6 +96,7 @@ describe("Refactor: mint", () => {
             );
         } catch (error) {
             console.error("Error fetching fees:", red(extractError(error)));
+            console.error(error);
             if (asset === "FIL") {
                 suggestedAmount = new BigNumber(0.2);
             } else {


### PR DESCRIPTION
Fees are now tracked in RenVM, so the in-contract fee getters are returning `0`. This PR fixes this by fetching the fees using `ren_queryBlockState`.