### PR TITLE
fix(ren-tx): submit error detection

### DIFF
--- a/packages/lib/ren-tx/src/configs/genericMint.ts
+++ b/packages/lib/ren-tx/src/configs/genericMint.ts
@@ -205,9 +205,8 @@ const handleSign = async <X>(
                 renResponse: hexify(
                     v._state.queryTxResult.out,
                 ) as LockAndMintTransaction,
-                renSignature: v._state.queryTxResult.out.signature?.toString(
-                    "hex",
-                ),
+                renSignature:
+                    v._state.queryTxResult.out.signature?.toString("hex"),
             };
             callback({
                 type: "SIGNED",
@@ -471,26 +470,25 @@ const mintFlow = <X>(
 };
 
 // Listen for confirmations on the source chain
-const depositListener = <X>(context: GatewayMachineContext<X>) => (
-    callback: Sender<GatewayMachineEvent<X>>,
-    receive: Receiver<any>,
-) => {
-    let cleanup = () => {};
+const depositListener =
+    <X>(context: GatewayMachineContext<X>) =>
+    (callback: Sender<GatewayMachineEvent<X>>, receive: Receiver<any>) => {
+        let cleanup = () => {};
 
-    initMinter(context, callback)
-        .then((minter) => {
-            cleanup = () => minter.removeAllListeners();
-            mintFlow(context, callback, receive, minter);
-            callback({ type: "LISTENING" });
-        })
-        .catch((e) => {
-            callback({ type: "ERROR_LISTENING", data: e });
-        });
+        initMinter(context, callback)
+            .then((minter) => {
+                cleanup = () => minter.removeAllListeners();
+                mintFlow(context, callback, receive, minter);
+                callback({ type: "LISTENING" });
+            })
+            .catch((e) => {
+                callback({ type: "ERROR_LISTENING", data: e });
+            });
 
-    return () => {
-        cleanup();
+        return () => {
+            cleanup();
+        };
     };
-};
 
 // Spawn an actor that will listen for either all deposits to a gatewayAddress,
 // or to a single deposit if present in the context

--- a/packages/lib/ren-tx/src/machines/burn.ts
+++ b/packages/lib/ren-tx/src/machines/burn.ts
@@ -364,6 +364,18 @@ export const buildBurnMachine = <BurnType, ReleaseType>() =>
                     // spawn in case we aren't creating
                     entry: "burnSpawner",
                     on: {
+                        BURN_ERROR: {
+                            target: "errorBurning",
+                            actions: assign({
+                                tx: (ctx, evt) =>
+                                    evt.data
+                                        ? {
+                                              ...ctx.tx,
+                                              error: evt.error,
+                                          }
+                                        : ctx.tx,
+                            }),
+                        },
                         // In case we restored and didn't submit
                         SUBMIT: {
                             actions: send("SUBMIT", {


### PR DESCRIPTION
Currently, "out of gas" errors won't be picked up by ren-tx, as we detect the ethereum tx and move into the destInitiated state. This PR fixes that by allowing movement into the errorSubmitting state after a tx has reverted, allowing us to resubmit.