### PR TITLE
feat(playground): support all chains and assets

### DIFF
--- a/packages/ui/playground/index.tsx
+++ b/packages/ui/playground/index.tsx
@@ -17,11 +17,12 @@ import {
     BasicBurn,
     DefaultDeposit,
     DepositProps,
+    BurnConfigMultiple,
+    MintConfigMultiple,
 } from "../../ui/ren-react/src/library/index";
-import { Ethereum, EthereumConfig } from "../../lib/chains/chains-ethereum/src";
+import { EthereumConfig } from "../../lib/chains/chains-ethereum/src";
 import { Solana } from "../../lib/chains/chains-solana/src";
-import { Bitcoin } from "../../lib/chains/chains-bitcoin";
-import { RenNetwork } from "@renproject/interfaces";
+import { MintChain, RenNetwork } from "@renproject/interfaces";
 import {
     WalletPickerModal,
     MultiwalletProvider,
@@ -29,7 +30,13 @@ import {
 } from "@renproject/multiwallet-ui";
 import { RenVMProvider } from "@renproject/rpc/build/main/v2/renVMProvider";
 import { multiwalletOptions } from "./multiwallet";
-import { chainStringToRenChain, lockChainMap, mintChainMap } from "./chainmaps";
+import {
+    burnChainMap,
+    chainStringToRenChain,
+    lockChainMap,
+    mintChainMap,
+    releaseChainMap,
+} from "./chainmaps";
 import { inspect } from "@xstate/inspect";
 
 inspect({
@@ -51,6 +58,8 @@ const ethLocalnetConfig: EthereumConfig = {
     chainLabel: "Localnet",
     networkID: 1337,
     infura: "http://localhost:8545",
+    publicProvider: () => "",
+    explorer: { address: () => "", transaction: () => "" },
     etherscan: "https://etherscan.io",
     addresses: {
         GatewayRegistry: "0x0Bb909b7c3817F8fB7188e8fbaA2763028956E30",
@@ -58,34 +67,46 @@ const ethLocalnetConfig: EthereumConfig = {
     },
 };
 
-const source = { BTC: "bitcoin", ZEC: "zcash", BCH: "bitcoinCash" };
-const supportedAssets = ["BTC", "ZEC", "BCH"];
+const source = {
+    BTC: "bitcoin",
+    ZEC: "zcash",
+    BCH: "bitcoinCash",
+    FIL: "filecoin",
+    DGB: "digiByte",
+    DOGE: "dogecoin",
+};
+const supportedAssets = ["BTC", "ZEC", "BCH", "FIL", "LUNA", "DGB", "DOGE"];
 const renNetworks = [...Object.values(RenNetwork)];
 
 const BasicBurnApp = ({
     network,
     account,
-    provider,
+    sourceChain,
+    sourceAsset,
+    destinationChain,
+    providers,
     destinationAddress,
     amount,
 }) => {
-    const parameters = useMemo(
+    const parameters: BurnConfigMultiple = useMemo(
         () => ({
-            sdk: new RenJS(network, { useV2TransactionFormat: true }),
+            debug: true,
+            sdk: new RenJS(network, { useV2TransactionFormat: true }) as any,
             burnParams: {
-                sourceAsset: "BTC",
+                sourceAsset,
                 network,
                 targetAmount: amount,
                 destinationAddress,
             },
-            from: new Solana(provider, network, {
-                logger: console,
-            }).Account({
-                amount,
-            }),
-            to: Bitcoin(network).Address(destinationAddress),
+            network,
+            sourceChain,
+            destinationChain,
+            userAddress: account,
+            customParams: {},
+            fromMap: burnChainMap(providers),
+            toMap: releaseChainMap,
         }),
-        [provider, account, amount, destinationAddress],
+        [providers, account, amount, destinationAddress],
     );
     return (
         <Typography component="div">
@@ -133,17 +154,18 @@ const BasicMintApp = ({ network, chain, account, providers, asset }) => {
         }
     }, [solanaMintChain, tokenAccountExists, setTokenAccountExists, asset]);
 
-    const parameters = useMemo(
+    const parameters: MintConfigMultiple = useMemo(
         () => ({
             sdk: new RenJS(network, {
                 loadCompletedDeposits: true,
                 useV2TransactionFormat: true,
-            }),
+            }) as any,
             mintParams: {
                 network,
                 sourceAsset: asset,
                 destinationAddress: account,
             },
+            debug: true,
             sourceChain: source[asset],
             userAddress: account,
             destinationChain: chain,
@@ -172,25 +194,23 @@ const BasicMintApp = ({ network, chain, account, providers, asset }) => {
     );
 };
 
-const ConnectToChain = ({ setOpen, setChain }) => {
+const ConnectToChain = ({ setOpen, setChain, network }) => {
     return (
         <Paper style={{ margin: "1em" }}>
-            {Object.keys(multiwalletOptions(RenNetwork.Mainnet).chains).map(
-                (chain) => (
-                    <Button
-                        variant="contained"
-                        style={{ margin: "1em", marginRight: "0" }}
-                        color="primary"
-                        key={chain}
-                        onClick={() => {
-                            setChain(chain);
-                            setOpen(true);
-                        }}
-                    >
-                        Connect To {chain}
-                    </Button>
-                ),
-            )}
+            {Object.keys(multiwalletOptions(network).chains).map((chain) => (
+                <Button
+                    variant="contained"
+                    style={{ margin: "1em", marginRight: "0" }}
+                    color="primary"
+                    key={chain}
+                    onClick={() => {
+                        setChain(chain);
+                        setOpen(true);
+                    }}
+                >
+                    Connect To {chain}
+                </Button>
+            ))}
         </Paper>
     );
 };
@@ -222,9 +242,10 @@ const DropdownSelect = ({ name, value, setValue, values }) => {
 };
 
 const App = (): JSX.Element => {
-    const [chain, setChain] = useState<
-        keyof ReturnType<typeof multiwalletOptions>["chains"]
-    >("solana");
+    const [chain, setChain] =
+        useState<keyof ReturnType<typeof multiwalletOptions>["chains"]>(
+            "solana",
+        );
     const [asset, setAsset] = useState("BTC");
     const [network, setNetwork] = useState(renNetworks[1]);
 
@@ -246,22 +267,37 @@ const App = (): JSX.Element => {
     const setClosed = useCallback(() => setOpen(false), [setOpen]);
 
     const [balances, setBalances] = useState<{ [chain: string]: string }>({});
+    const [decimals, setDecimals] = useState<{
+        [chain: string]: { [asset: string]: number };
+    }>({});
     useEffect(() => {
-        Object.entries(wallets.enabledChains).map(([chain, connector]) => {
-            const provider = connector.provider as any;
-            const account = connector.account as string;
+        Object.entries(wallets.enabledChains).map(
+            async ([chain, connector]) => {
+                const provider = connector.provider as any;
+                const account = connector.account as string;
 
-            if (!provider || !account) return;
-            new chainStringToRenChain[chain](provider, network)
-                .getBalance(asset, account)
-                .then((value) =>
-                    setBalances((balances) => ({
-                        ...balances,
-                        [chain]: value.toString(),
-                    })),
+                if (!provider || !account) return;
+                const mintChain: MintChain = chainStringToRenChain[chain](
+                    provider,
+                    network,
                 );
-        });
-    }, [wallets, setBalances]);
+                const balance = await mintChain.getBalance(asset, account);
+                setBalances((balances) => ({
+                    ...balances,
+                    [chain]: balance.toString(),
+                }));
+
+                const decimals = await mintChain.assetDecimals(asset);
+                setDecimals((oldDecimals) => ({
+                    ...oldDecimals,
+                    [chain]: {
+                        ...oldDecimals[chain],
+                        [asset]: decimals,
+                    },
+                }));
+            },
+        );
+    }, [wallets, setBalances, setDecimals]);
 
     return (
         <Container
@@ -277,8 +313,8 @@ const App = (): JSX.Element => {
                 }}
             />
             <ConnectToChain
-                enabledChains={wallets.enabledChains}
                 setOpen={setOpen}
+                network={network}
                 setChain={setChain}
             />
             <Container
@@ -330,7 +366,9 @@ const App = (): JSX.Element => {
                                 Burn from {chain}
                             </Typography>
                             <Typography>
-                                {asset} Balance: {balances[chain]}
+                                {asset} Balance:{" "}
+                                {Number(balances[chain]) /
+                                    10 ** (decimals[chain] || {})[asset]}
                             </Typography>
                             <Input
                                 placeholder="recipient address"
@@ -347,10 +385,11 @@ const App = (): JSX.Element => {
                             />
                             {address.length > 0 && (
                                 <BasicBurnApp
-                                    provider={
-                                        wallets.enabledChains[chain].provider
-                                    }
+                                    providers={wallets.enabledChains}
                                     network={network}
+                                    sourceChain={chain}
+                                    sourceAsset={asset}
+                                    destinationChain={source[asset]}
                                     account={
                                         wallets.enabledChains[chain].account
                                     }

--- a/packages/ui/playground/multiwallet.ts
+++ b/packages/ui/playground/multiwallet.ts
@@ -51,11 +51,24 @@ export const multiwalletOptions = (
     network: RenNetwork,
 ): WalletPickerConfig<unknown, string> => ({
     chains: {
+        avalance: [
+            {
+                name: "Metamask",
+                logo: "https://avatars2.githubusercontent.com/u/45615063?s=60&v=4",
+                connector: (() => {
+                    const connector = new EthereumInjectedConnector({
+                        networkIdMapper: avalancheNetworkToRenNetwork,
+                        debug: true,
+                    });
+                    connector.getProvider = () => (window as any).ethereum;
+                    return connector;
+                })(),
+            },
+        ],
         solana: [
             {
                 name: "Sollet.io",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/69240779?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/69240779?s=60&v=4",
                 connector: new SolanaConnector({
                     debug: true,
                     providerURL: "https://www.sollet.io",
@@ -64,8 +77,7 @@ export const multiwalletOptions = (
             },
             {
                 name: "Phantom",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/78782331?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/78782331?s=60&v=4",
                 connector: new SolanaConnector({
                     debug: true,
                     providerURL: (window as any).solana,
@@ -76,8 +88,7 @@ export const multiwalletOptions = (
         moonbeam: [
             {
                 name: "Metamask",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
                 connector: new EthereumInjectedConnector({
                     debug: true,
                     networkIdMapper: () => RenNetwork.Testnet,
@@ -87,8 +98,7 @@ export const multiwalletOptions = (
         polygon: [
             {
                 name: "Metamask",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
                 connector: new EthereumInjectedConnector({
                     debug: true,
                     networkIdMapper: polygonNetworkToRenNetwork,
@@ -98,8 +108,7 @@ export const multiwalletOptions = (
         fantom: [
             {
                 name: "Metamask",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
                 connector: new EthereumInjectedConnector({
                     debug: true,
                     networkIdMapper: fantomNetworkToRenNetwork,
@@ -109,8 +118,7 @@ export const multiwalletOptions = (
         ethereum: [
             {
                 name: "Metamask",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
                 connector: new EthereumInjectedConnector({
                     debug: true,
                     networkIdMapper: ethNetworkToRenNetwork,
@@ -143,11 +151,10 @@ export const multiwalletOptions = (
              *     }),
              * }, */
         ],
-        bsc: [
+        binanceSmartChain: [
             {
                 name: "BinanceSmartWallet",
-                logo:
-                    "https://avatars2.githubusercontent.com/u/45615063?s=60&v=4",
+                logo: "https://avatars2.githubusercontent.com/u/45615063?s=60&v=4",
                 connector: new BinanceSmartChainInjectedConnector({
                     debug: true,
                 }),

--- a/packages/ui/playground/yarn.lock
+++ b/packages/ui/playground/yarn.lock
@@ -6768,10 +6768,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web3-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.4.0.tgz#e8cb381c81b242dc1d4ecb397200356d404410e6"
-  integrity sha512-b8mEhwh/J928Xk+SQFjtqrR2EGPhpknWLcIt9aCpVPVRXiqjUGo/kpOHKz0azu9c6/onEJ9tWXZt0cVjmH0N5Q==
+web3-utils@3.0.0-rc.5:
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-3.0.0-rc.5.tgz#f23fb03ee968f9cbbfdd50a5855759d968f2f4c9"
+  integrity sha512-TwYrNKXCrJJy7/ZRwZpipMf6Aq/ygsHbdvgXgCd/gJ18SYR9f8wn14zHHoZ8Xg7Sk3sDtf+A+lGPA6Y1mxzfGw==
   dependencies:
     bn.js "^4.11.9"
     eth-lib "0.2.8"

--- a/packages/ui/ren-react/src/library/Components/BurnAndReleaseComponents.tsx
+++ b/packages/ui/ren-react/src/library/Components/BurnAndReleaseComponents.tsx
@@ -29,7 +29,11 @@ const DefaultConfirmingBurn: React.FC<ConfirmingBurnProps> = ({
         <div className="confirmingBurn">
             Waiting for burn confirmation {confirmations}/
             {targetConfirmations || "?"}
-            {explorerLink && <a href={explorerLink}>Explorer Link</a>}
+            {explorerLink && (
+                <div>
+                    <a href={explorerLink}>Explorer Link</a>
+                </div>
+            )}
         </div>
     );
 };
@@ -91,10 +95,14 @@ const DefaultAcceptedBurn: React.FC<AcceptedBurnProps> = ({
         <div className="acceptedBurn">
             Burned {amount}
             {burnExplorerLink && (
-                <a href={burnExplorerLink}>Burn Explorer Link</a>
+                <div>
+                    <a href={burnExplorerLink}>Burn Explorer Link</a>
+                </div>
             )}
             {releaseExplorerLink && (
-                <a href={burnExplorerLink}>Release Explorer Link</a>
+                <div>
+                    <a href={burnExplorerLink}>Release Explorer Link</a>
+                </div>
             )}
         </div>
     );
@@ -116,7 +124,11 @@ const DefaultCompletedBurn: React.FC<CompletedBurnProps> = ({
         <div className="completed-burn">
             Successfully burned {amount}{" "}
             {txHash ? ` in release tx: ${txHash}` : ""}
-            {explorerLink && <a href={explorerLink}>Explorer Link</a>}
+            {explorerLink && (
+                <div>
+                    <a href={explorerLink}>Explorer Link</a>
+                </div>
+            )}
         </div>
     );
 };

--- a/packages/ui/ren-react/src/library/Components/LockAndMintComponents.tsx
+++ b/packages/ui/ren-react/src/library/Components/LockAndMintComponents.tsx
@@ -31,17 +31,20 @@ export interface ConfirmingDepositProps<X> {
     targetConfirmations?: number;
 }
 
-export const DefaultConfirmingDeposit: React.FC<
-    ConfirmingDepositProps<any>
-> = ({ confirmations, targetConfirmations, explorerLink }) => {
-    return (
-        <div className="confirmingDeposit">
-            Waiting for deposit confirmation {confirmations}/
-            {targetConfirmations || "?"}
-            {explorerLink && <a href={explorerLink}>Explorer Link</a>}
-        </div>
-    );
-};
+export const DefaultConfirmingDeposit: React.FC<ConfirmingDepositProps<any>> =
+    ({ confirmations, targetConfirmations, explorerLink }) => {
+        return (
+            <div className="confirmingDeposit">
+                Waiting for deposit confirmation {confirmations}/
+                {targetConfirmations || "?"}
+                {explorerLink && (
+                    <div>
+                        <a href={explorerLink}>Explorer Link</a>
+                    </div>
+                )}
+            </div>
+        );
+    };
 
 export interface SigningDepositProps {
     deposit: ConfirmingGatewayTransaction<any>;
@@ -55,13 +58,14 @@ export interface SubmittingMintDepositProps {
     deposit: SubmittingGatewayTransaction<any>;
 }
 
-export const DefaultSubmittingMintDeposit: React.FC<SubmittingMintDepositProps> = () => {
-    return (
-        <div className="submittingMint">
-            Please sign the transaction in your wallet
-        </div>
-    );
-};
+export const DefaultSubmittingMintDeposit: React.FC<SubmittingMintDepositProps> =
+    () => {
+        return (
+            <div className="submittingMint">
+                Please sign the transaction in your wallet
+            </div>
+        );
+    };
 
 export interface MintingDepositProps {
     deposit: SubmittingGatewayTransaction<any>;
@@ -103,7 +107,11 @@ export const DefaultCompletedDeposit: React.FC<CompletedDepositProps> = ({
     return (
         <div className="acceptedDeposit">
             Successfully minted {String(amount)}, tx: {String(tx)}
-            {explorerLink && <a href={explorerLink}>Explorer Link</a>}
+            {explorerLink && (
+                <div>
+                    <a href={explorerLink}>Explorer Link</a>
+                </div>
+            )}
         </div>
     );
 };
@@ -132,13 +140,14 @@ export interface ErrorRestoringDepositProps {
     reason: string;
 }
 
-export const DefaultErrorRestoringDeposit: React.FC<ErrorRestoringDepositProps> = ({
-    reason,
-}) => {
-    return (
-        <div className="errorRestoringDeposit">Error Restoring {reason}</div>
-    );
-};
+export const DefaultErrorRestoringDeposit: React.FC<ErrorRestoringDepositProps> =
+    ({ reason }) => {
+        return (
+            <div className="errorRestoringDeposit">
+                Error Restoring {reason}
+            </div>
+        );
+    };
 
 export interface ErrorMintingDepositProps {
     deposit: GatewayTransaction<any>;
@@ -245,7 +254,9 @@ export const DefaultDeposit: React.FC<DepositProps> = ({
             return (
                 <CompletedDeposit
                     deposit={deposit}
-                    amount={(deposit.renResponse?.out as any)?.amount}
+                    amount={formatAmount(
+                        (deposit.renResponse?.out as any)?.amount,
+                    )}
                     tx={deposit.destTxHash || ""}
                     explorerLink={mintExplorerLink}
                 />


### PR DESCRIPTION
The ren-js UI playground has been semi-incomplete until now, only supporting 1 manual chain for burning, and partial multi-chain support for minting. 

This PR fixes that, allowing users to mint & burn on mainnet & testnet, on all supported chains. With minor configuration, it also supports using a local ethereum network as well as ren devnet / localnet, allowing for easy UI development.