### PR TITLE
fix(solana): recipient for filecoin terra burns

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.4.5"
+    "version": "2.4.6-alpha.0"
 }

--- a/packages/lib/chains/chains-bitcoin/package.json
+++ b/packages/lib/chains/chains-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-bitcoin",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -44,9 +44,9 @@
     },
     "dependencies": {
         "@CoinSpace/bitcore-lib-dogecoin": "CoinSpace/bitcore-lib-dogecoin",
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/rpc": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/rpc": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@types/bs58": "^4.0.1",
         "@types/cashaddrjs": "^0.3.0",
         "@types/node": ">=10",

--- a/packages/lib/chains/chains-bitcoin/src/base.ts
+++ b/packages/lib/chains/chains-bitcoin/src/base.ts
@@ -291,6 +291,14 @@ export abstract class BitcoinBaseChain
         }
     };
 
+    /**
+     * See [[LockChain.bytesToAddress]].
+     */
+    bytesToAddress = (address: Buffer): string => {
+        const words = bech32.toWords(address);
+        return bech32.encode("", words);
+    };
+
     /** @deprecated. Renamed to addressToBytes. */
     addressStringToBytes = this.addressToBytes;
 

--- a/packages/lib/chains/chains-ethereum/package.json
+++ b/packages/lib/chains/chains-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-ethereum",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,8 +43,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/chains/chains-filecoin/package.json
+++ b/packages/lib/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,9 +45,9 @@
     "dependencies": {
         "@glif/filecoin-address": "^1.1.0",
         "@glif/filecoin-rpc-client": "^1.1.0",
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/rpc": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/rpc": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@types/elliptic": "^6.4.12",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/chains/chains-filecoin/src/filecoin.ts
+++ b/packages/lib/chains/chains-filecoin/src/filecoin.ts
@@ -386,6 +386,11 @@ export class FilecoinClass
             ).str,
         );
 
+    /**
+     * See [[LockChain.addressToBytes]].
+     */
+    bytesToAddress = (address: Buffer): string => encodeAddress(address);
+
     /** @deprecated. Renamed to addressToBytes. */
     addressStringToBytes = this.addressToBytes;
 

--- a/packages/lib/chains/chains-solana/package.json
+++ b/packages/lib/chains/chains-solana/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-solana",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,9 +45,9 @@
     "dependencies": {
         "@project-serum/associated-token": "^0.1.1",
         "@project-serum/borsh": "^0.2.2",
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/rpc": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/rpc": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@solana/spl-token": "^0.1.5",
         "@solana/web3.js": "^1.19.0",
         "@types/bn.js": "^5.1.0",

--- a/packages/lib/chains/chains-solana/src/index.ts
+++ b/packages/lib/chains/chains-solana/src/index.ts
@@ -71,7 +71,10 @@ const x =
     () =>
         a;
 
-const encodeAddress = (asset: string): ((b: Buffer) => Promise<string>) => {
+const encodeAddress = (
+    asset: string,
+    network: "mainnet" | "testnet",
+): ((b: Buffer) => Promise<string>) => {
     switch (asset) {
         case "BTC":
         case "ZEC":
@@ -88,7 +91,7 @@ const encodeAddress = (asset: string): ((b: Buffer) => Promise<string>) => {
                 const { Filecoin } = await import(
                     "@renproject/chains-filecoin"
                 );
-                return new Filecoin().bytesToAddress(bytes);
+                return new Filecoin(network).bytesToAddress(bytes);
             };
     }
     throw new Error("Unknown asset: " + asset);
@@ -1005,7 +1008,10 @@ export class SolanaClass
         const x: BurnDetails<SolTransaction> = {
             transaction: res,
             amount: new BigNumber(amount),
-            to: await encodeAddress(asset)(recipient),
+            to: await encodeAddress(
+                asset,
+                this.renNetwork?.isTestnet ? "testnet" : "mainnet",
+            )(recipient),
             nonce: new BigNumber(nonceBN.toString()),
         };
         return x;

--- a/packages/lib/chains/chains-solana/src/networks.ts
+++ b/packages/lib/chains/chains-solana/src/networks.ts
@@ -76,7 +76,7 @@ export const renTestnet: SolNetworkConfig = {
     chain: "testnet",
     isTestnet: true,
     chainLabel: "Testnet",
-    endpoint: "https://api.testnet.solana.com",
+    endpoint: "https://api.devnet.solana.com",
     chainExplorer: "https://explorer.solana.com",
     lightnode: "https://lightnode-testnet.herokuapp.com",
     addresses: {

--- a/packages/lib/chains/chains-solana/src/networks.ts
+++ b/packages/lib/chains/chains-solana/src/networks.ts
@@ -76,7 +76,7 @@ export const renTestnet: SolNetworkConfig = {
     chain: "testnet",
     isTestnet: true,
     chainLabel: "Testnet",
-    endpoint: "https://testnet.solana.com",
+    endpoint: "https://api.testnet.solana.com",
     chainExplorer: "https://explorer.solana.com",
     lightnode: "https://lightnode-testnet.herokuapp.com",
     addresses: {

--- a/packages/lib/chains/chains-solana/tsconfig.module.json
+++ b/packages/lib/chains/chains-solana/tsconfig.module.json
@@ -1,9 +1,9 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "target": "es6",
+        "target": "es2020",
         "outDir": "build/module",
-        "module": "es6"
+        "module": "es2020"
     },
     "exclude": ["node_modules/**"]
 }

--- a/packages/lib/chains/chains-terra/package.json
+++ b/packages/lib/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/rpc": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/rpc": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@terra-money/terra.js": "1.3.6",
         "@types/elliptic": "^6.4.12",
         "@types/node": ">=10",

--- a/packages/lib/chains/chains-terra/src/terra.ts
+++ b/packages/lib/chains/chains-terra/src/terra.ts
@@ -6,6 +6,7 @@ import {
     RenNetwork,
     RenNetworkDetails,
     RenNetworkString,
+    BurnPayloadConfig,
 } from "@renproject/interfaces";
 import {
     assertType,
@@ -274,6 +275,14 @@ export class TerraClass
             ),
         );
 
+    /**
+     * See [[LockChain.bytesToAddress]].
+     */
+    bytesToAddress = (address: Buffer): string => {
+        const words = bech32.toWords(address);
+        return bech32.encode("terra", words);
+    };
+
     /** @deprecated. Renamed to addressToBytes. */
     addressStringToBytes = this.addressToBytes;
 
@@ -326,18 +335,21 @@ export class TerraClass
     transactionRPCTxidFromID = (transactionID: string): Buffer =>
         Buffer.from(transactionID, "hex");
 
-    getBurnPayload: (() => string) | undefined;
+    getBurnPayload: ((bytes?: boolean) => string) | undefined;
 
     Address = (address: string): this => {
         // Type validation
         assertType<string>("string", { address });
 
-        this.getBurnPayload = () => address;
+        this.getBurnPayload = (bytes) =>
+            bytes ? this.addressToBytes(address).toString("hex") : address;
         return this;
     };
 
-    burnPayload? = () => {
-        return this.getBurnPayload ? this.getBurnPayload() : undefined;
+    burnPayload? = (config?: BurnPayloadConfig) => {
+        return this.getBurnPayload
+            ? this.getBurnPayload(config?.bytes)
+            : undefined;
     };
 }
 

--- a/packages/lib/chains/chains/package.json
+++ b/packages/lib/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,12 +43,12 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^2.4.5",
-        "@renproject/chains-ethereum": "^2.4.5",
-        "@renproject/chains-filecoin": "^2.4.5",
-        "@renproject/chains-solana": "^2.4.5",
-        "@renproject/chains-terra": "^2.4.5",
-        "@renproject/interfaces": "^2.4.5",
+        "@renproject/chains-bitcoin": "^2.4.6-alpha.0",
+        "@renproject/chains-ethereum": "^2.4.6-alpha.0",
+        "@renproject/chains-filecoin": "^2.4.6-alpha.0",
+        "@renproject/chains-solana": "^2.4.6-alpha.0",
+        "@renproject/chains-terra": "^2.4.6-alpha.0",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/interfaces/package.json
+++ b/packages/lib/interfaces/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/interfaces",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/lib/interfaces/src/chain.ts
+++ b/packages/lib/interfaces/src/chain.ts
@@ -268,6 +268,14 @@ export interface LockChain<
     addressToBytes: (address: Address | string) => Buffer;
 
     /**
+     * `bytesToAddress` should return the string representation of the address.
+     *
+     * @dev Must be compatible with the matching RenVM multichain LockChain's
+     * `encodeAddress` method.
+     */
+    bytesToAddress: (bytes: Buffer) => Address | string;
+
+    /**
      * @deprecated Renamed to addressToBytes.
      */
     addressStringToBytes: (address: string) => Buffer;

--- a/packages/lib/multiwallet/multiwallet-abstract-ethereum-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-abstract-ethereum-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-abstract-ethereum-connector",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/chains-ethereum": "^2.4.5",
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/multiwallet-base-connector": "^2.4.5",
+        "@renproject/chains-ethereum": "^2.4.6-alpha.0",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.4.6-alpha.0",
         "@types/node": ">=10",
         "web3": "^3.0.0-rc.5"
     },

--- a/packages/lib/multiwallet/multiwallet-base-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-base-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-base-connector",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
         "@types/events": "3.0.0",
         "@types/node": ">=10",
         "events": "3.2.0"

--- a/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-binancesmartchain-injected-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-binancesmartchain-injected-connector",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,9 +41,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.4.5",
-        "@renproject/multiwallet-ethereum-injected-connector": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-ethereum-injected-connector": "^2.4.6-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-injected-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-injected-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-injected-connector",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,8 +41,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.4.5",
-        "@renproject/multiwallet-base-connector": "^2.4.5",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.4.6-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-mewconnect-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-mewconnect-connector",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
     },
     "dependencies": {
         "@myetherwallet/mewconnect-web-client": "^2.1.23-beta.9",
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.4.5",
-        "@renproject/multiwallet-base-connector": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.4.6-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-ethereum-walletconnect-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-ethereum-walletconnect-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-ethereum-walletconnect-connector",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -41,9 +41,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/multiwallet-abstract-ethereum-connector": "^2.4.5",
-        "@renproject/multiwallet-base-connector": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-abstract-ethereum-connector": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.4.6-alpha.0",
         "@types/node": ">=10",
         "@walletconnect/web3-provider": "^1.4.1"
     },

--- a/packages/lib/multiwallet/multiwallet-solana-connector/package.json
+++ b/packages/lib/multiwallet/multiwallet-solana-connector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/multiwallet-solana-connector",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -46,8 +46,8 @@
     },
     "dependencies": {
         "@project-serum/sol-wallet-adapter": "^0.1.6",
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/multiwallet-base-connector": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/multiwallet-base-connector": "^2.4.6-alpha.0",
         "@types/node": ">=10"
     },
     "resolutions": {

--- a/packages/lib/multiwallet/multiwallet-solana-connector/src/index.ts
+++ b/packages/lib/multiwallet/multiwallet-solana-connector/src/index.ts
@@ -17,8 +17,8 @@ export interface SolanaConnectorOptions {
 const renNetworkToSolanaNetwork: { [k in RenNetwork]: string } = {
     [RenNetwork.DevnetVDot3]: clusterApiUrl("devnet"),
     [RenNetwork.Mainnet]: clusterApiUrl("mainnet-beta"),
-    [RenNetwork.Testnet]: clusterApiUrl("testnet"),
-    [RenNetwork.TestnetVDot3]: clusterApiUrl("testnet"),
+    [RenNetwork.Testnet]: clusterApiUrl("devnet"),
+    [RenNetwork.TestnetVDot3]: clusterApiUrl("devnet"),
     [RenNetwork.MainnetVDot3]: clusterApiUrl("mainnet-beta"),
     [RenNetwork.Localnet]: "http://localhost:8899",
 };

--- a/packages/lib/provider/package.json
+++ b/packages/lib/provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/provider",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,8 +43,8 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@types/node": ">=10",
         "axios": "^0.21.1",
         "immutable": "^4.0.0-rc.12"

--- a/packages/lib/ren-tx/package.json
+++ b/packages/lib/ren-tx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren-tx",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "description": "XState Statemachines for tracking RenVM transactions reactively",
     "repository": {
         "type": "git",
@@ -46,9 +46,9 @@
         "bignumber.js": "^9.0.1"
     },
     "devDependencies": {
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/ren": "^2.4.5",
-        "@renproject/rpc": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/ren": "^2.4.6-alpha.0",
+        "@renproject/rpc": "^2.4.6-alpha.0",
         "dotenv": "^8.2.0",
         "xstate": "^4.17.0"
     },

--- a/packages/lib/ren/package.json
+++ b/packages/lib/ren/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "description": "Official Ren JavaScript SDK for bridging crypto assets cross-chain.",
     "repository": {
         "type": "git",
@@ -62,10 +62,10 @@
         "prepare-release": "run-s npmignore build doc:html doc:publish"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/provider": "^2.4.5",
-        "@renproject/rpc": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/provider": "^2.4.6-alpha.0",
+        "@renproject/rpc": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",

--- a/packages/lib/rpc/package.json
+++ b/packages/lib/rpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/rpc",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "description": "Official Ren JavaScript client",
     "repository": {
         "type": "git",
@@ -53,9 +53,9 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/provider": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/provider": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "immutable": "^4.0.0-rc.12"

--- a/packages/lib/test/package.json
+++ b/packages/lib/test/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test",
     "private": true,
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "scripts": {
         "describe": "npm-scripts-info",
         "prettier": "yarn fix:prettier",
@@ -24,13 +24,13 @@
         "build:module": "tsc -p tsconfig.module.json"
     },
     "dependencies": {
-        "@renproject/chains": "^2.4.5",
-        "@renproject/chains-terra": "^2.4.5",
-        "@renproject/interfaces": "^2.4.5",
-        "@renproject/provider": "^2.4.5",
-        "@renproject/ren": "^2.4.5",
-        "@renproject/rpc": "^2.4.5",
-        "@renproject/utils": "^2.4.5",
+        "@renproject/chains": "^2.4.6-alpha.0",
+        "@renproject/chains-terra": "^2.4.6-alpha.0",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
+        "@renproject/provider": "^2.4.6-alpha.0",
+        "@renproject/ren": "^2.4.6-alpha.0",
+        "@renproject/rpc": "^2.4.6-alpha.0",
+        "@renproject/utils": "^2.4.6-alpha.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "immutable": "^4.0.0-rc.12",

--- a/packages/lib/utils/package.json
+++ b/packages/lib/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/utils",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,7 +43,7 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@renproject/interfaces": "^2.4.5",
+        "@renproject/interfaces": "^2.4.6-alpha.0",
         "@types/create-hash": "1.2.2",
         "@types/keccak": "^3.0.1",
         "@types/mocha": "^8.2.0",

--- a/packages/ui/multiwallet-ui/package.json
+++ b/packages/ui/multiwallet-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renproject/multiwallet-ui",
   "author": "renproject",
-  "version": "2.4.5",
+  "version": "2.4.6-alpha.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -28,8 +28,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@renproject/interfaces": "^2.4.5",
-    "@renproject/multiwallet-base-connector": "^2.4.5"
+    "@renproject/interfaces": "^2.4.6-alpha.0",
+    "@renproject/multiwallet-base-connector": "^2.4.6-alpha.0"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.11.0",

--- a/packages/ui/playground/index.tsx
+++ b/packages/ui/playground/index.tsx
@@ -74,6 +74,7 @@ const source = {
     FIL: "filecoin",
     DGB: "digiByte",
     DOGE: "dogecoin",
+    LUNA: "terra",
 };
 const supportedAssets = ["BTC", "ZEC", "BCH", "FIL", "LUNA", "DGB", "DOGE"];
 const renNetworks = [...Object.values(RenNetwork)];

--- a/packages/ui/playground/index.tsx
+++ b/packages/ui/playground/index.tsx
@@ -17,11 +17,12 @@ import {
     BasicBurn,
     DefaultDeposit,
     DepositProps,
+    BurnConfigMultiple,
+    MintConfigMultiple,
 } from "../../ui/ren-react/src/library/index";
-import { Ethereum, EthereumConfig } from "../../lib/chains/chains-ethereum/src";
+import { EthereumConfig } from "../../lib/chains/chains-ethereum/src";
 import { Solana } from "../../lib/chains/chains-solana/src";
-import { Bitcoin } from "../../lib/chains/chains-bitcoin";
-import { RenNetwork } from "@renproject/interfaces";
+import { MintChain, RenNetwork } from "@renproject/interfaces";
 import {
     WalletPickerModal,
     MultiwalletProvider,
@@ -29,7 +30,13 @@ import {
 } from "@renproject/multiwallet-ui";
 import { RenVMProvider } from "@renproject/rpc/build/main/v2/renVMProvider";
 import { multiwalletOptions } from "./multiwallet";
-import { chainStringToRenChain, lockChainMap, mintChainMap } from "./chainmaps";
+import {
+    burnChainMap,
+    chainStringToRenChain,
+    lockChainMap,
+    mintChainMap,
+    releaseChainMap,
+} from "./chainmaps";
 import { inspect } from "@xstate/inspect";
 
 inspect({
@@ -51,6 +58,8 @@ const ethLocalnetConfig: EthereumConfig = {
     chainLabel: "Localnet",
     networkID: 1337,
     infura: "http://localhost:8545",
+    publicProvider: () => "",
+    explorer: { address: () => "", transaction: () => "" },
     etherscan: "https://etherscan.io",
     addresses: {
         GatewayRegistry: "0x0Bb909b7c3817F8fB7188e8fbaA2763028956E30",
@@ -58,34 +67,46 @@ const ethLocalnetConfig: EthereumConfig = {
     },
 };
 
-const source = { BTC: "bitcoin", ZEC: "zcash", BCH: "bitcoinCash" };
-const supportedAssets = ["BTC", "ZEC", "BCH"];
+const source = {
+    BTC: "bitcoin",
+    ZEC: "zcash",
+    BCH: "bitcoinCash",
+    FIL: "filecoin",
+    DGB: "digiByte",
+    DOGE: "dogecoin",
+};
+const supportedAssets = ["BTC", "ZEC", "BCH", "FIL", "LUNA", "DGB", "DOGE"];
 const renNetworks = [...Object.values(RenNetwork)];
 
 const BasicBurnApp = ({
     network,
     account,
-    provider,
+    sourceChain,
+    sourceAsset,
+    destinationChain,
+    providers,
     destinationAddress,
     amount,
 }) => {
-    const parameters = useMemo(
+    const parameters: BurnConfigMultiple = useMemo(
         () => ({
-            sdk: new RenJS(network, { useV2TransactionFormat: true }),
+            debug: true,
+            sdk: new RenJS(network, { useV2TransactionFormat: true }) as any,
             burnParams: {
-                sourceAsset: "BTC",
+                sourceAsset,
                 network,
                 targetAmount: amount,
                 destinationAddress,
             },
-            from: new Solana(provider, network, {
-                logger: console,
-            }).Account({
-                amount,
-            }),
-            to: Bitcoin(network).Address(destinationAddress),
+            network,
+            sourceChain,
+            destinationChain,
+            userAddress: account,
+            customParams: {},
+            fromMap: burnChainMap(providers),
+            toMap: releaseChainMap,
         }),
-        [provider, account, amount, destinationAddress],
+        [providers, account, amount, destinationAddress],
     );
     return (
         <Typography component="div">
@@ -133,17 +154,18 @@ const BasicMintApp = ({ network, chain, account, providers, asset }) => {
         }
     }, [solanaMintChain, tokenAccountExists, setTokenAccountExists, asset]);
 
-    const parameters = useMemo(
+    const parameters: MintConfigMultiple = useMemo(
         () => ({
             sdk: new RenJS(network, {
                 loadCompletedDeposits: true,
                 useV2TransactionFormat: true,
-            }),
+            }) as any,
             mintParams: {
                 network,
                 sourceAsset: asset,
                 destinationAddress: account,
             },
+            debug: true,
             sourceChain: source[asset],
             userAddress: account,
             destinationChain: chain,
@@ -172,25 +194,23 @@ const BasicMintApp = ({ network, chain, account, providers, asset }) => {
     );
 };
 
-const ConnectToChain = ({ setOpen, setChain }) => {
+const ConnectToChain = ({ setOpen, setChain, network }) => {
     return (
         <Paper style={{ margin: "1em" }}>
-            {Object.keys(multiwalletOptions(RenNetwork.Mainnet).chains).map(
-                (chain) => (
-                    <Button
-                        variant="contained"
-                        style={{ margin: "1em", marginRight: "0" }}
-                        color="primary"
-                        key={chain}
-                        onClick={() => {
-                            setChain(chain);
-                            setOpen(true);
-                        }}
-                    >
-                        Connect To {chain}
-                    </Button>
-                ),
-            )}
+            {Object.keys(multiwalletOptions(network).chains).map((chain) => (
+                <Button
+                    variant="contained"
+                    style={{ margin: "1em", marginRight: "0" }}
+                    color="primary"
+                    key={chain}
+                    onClick={() => {
+                        setChain(chain);
+                        setOpen(true);
+                    }}
+                >
+                    Connect To {chain}
+                </Button>
+            ))}
         </Paper>
     );
 };
@@ -222,9 +242,10 @@ const DropdownSelect = ({ name, value, setValue, values }) => {
 };
 
 const App = (): JSX.Element => {
-    const [chain, setChain] = useState<
-        keyof ReturnType<typeof multiwalletOptions>["chains"]
-    >("solana");
+    const [chain, setChain] =
+        useState<keyof ReturnType<typeof multiwalletOptions>["chains"]>(
+            "solana",
+        );
     const [asset, setAsset] = useState("BTC");
     const [network, setNetwork] = useState(renNetworks[1]);
 
@@ -246,22 +267,37 @@ const App = (): JSX.Element => {
     const setClosed = useCallback(() => setOpen(false), [setOpen]);
 
     const [balances, setBalances] = useState<{ [chain: string]: string }>({});
+    const [decimals, setDecimals] = useState<{
+        [chain: string]: { [asset: string]: number };
+    }>({});
     useEffect(() => {
-        Object.entries(wallets.enabledChains).map(([chain, connector]) => {
-            const provider = connector.provider as any;
-            const account = connector.account as string;
+        Object.entries(wallets.enabledChains).map(
+            async ([chain, connector]) => {
+                const provider = connector.provider as any;
+                const account = connector.account as string;
 
-            if (!provider || !account) return;
-            new chainStringToRenChain[chain](provider, network)
-                .getBalance(asset, account)
-                .then((value) =>
-                    setBalances((balances) => ({
-                        ...balances,
-                        [chain]: value.toString(),
-                    })),
+                if (!provider || !account) return;
+                const mintChain: MintChain = chainStringToRenChain[chain](
+                    provider,
+                    network,
                 );
-        });
-    }, [wallets, setBalances]);
+                const balance = await mintChain.getBalance(asset, account);
+                setBalances((balances) => ({
+                    ...balances,
+                    [chain]: balance.toString(),
+                }));
+
+                const decimals = await mintChain.assetDecimals(asset);
+                setDecimals((oldDecimals) => ({
+                    ...oldDecimals,
+                    [chain]: {
+                        ...oldDecimals[chain],
+                        [asset]: decimals,
+                    },
+                }));
+            },
+        );
+    }, [wallets, setBalances, setDecimals]);
 
     return (
         <Container
@@ -277,8 +313,8 @@ const App = (): JSX.Element => {
                 }}
             />
             <ConnectToChain
-                enabledChains={wallets.enabledChains}
                 setOpen={setOpen}
+                network={network}
                 setChain={setChain}
             />
             <Container
@@ -330,7 +366,9 @@ const App = (): JSX.Element => {
                                 Burn from {chain}
                             </Typography>
                             <Typography>
-                                {asset} Balance: {balances[chain]}
+                                {asset} Balance:{" "}
+                                {Number(balances[chain]) /
+                                    10 ** (decimals[chain] || {})[asset]}
                             </Typography>
                             <Input
                                 placeholder="recipient address"
@@ -347,10 +385,11 @@ const App = (): JSX.Element => {
                             />
                             {address.length > 0 && (
                                 <BasicBurnApp
-                                    provider={
-                                        wallets.enabledChains[chain].provider
-                                    }
+                                    providers={wallets.enabledChains}
                                     network={network}
+                                    sourceChain={chain}
+                                    sourceAsset={asset}
+                                    destinationChain={source[asset]}
                                     account={
                                         wallets.enabledChains[chain].account
                                     }

--- a/packages/ui/playground/multiwallet.ts
+++ b/packages/ui/playground/multiwallet.ts
@@ -51,11 +51,24 @@ export const multiwalletOptions = (
     network: RenNetwork,
 ): WalletPickerConfig<unknown, string> => ({
     chains: {
+        avalance: [
+            {
+                name: "Metamask",
+                logo: "https://avatars2.githubusercontent.com/u/45615063?s=60&v=4",
+                connector: (() => {
+                    const connector = new EthereumInjectedConnector({
+                        networkIdMapper: avalancheNetworkToRenNetwork,
+                        debug: true,
+                    });
+                    connector.getProvider = () => (window as any).ethereum;
+                    return connector;
+                })(),
+            },
+        ],
         solana: [
             {
                 name: "Sollet.io",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/69240779?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/69240779?s=60&v=4",
                 connector: new SolanaConnector({
                     debug: true,
                     providerURL: "https://www.sollet.io",
@@ -64,8 +77,7 @@ export const multiwalletOptions = (
             },
             {
                 name: "Phantom",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/78782331?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/78782331?s=60&v=4",
                 connector: new SolanaConnector({
                     debug: true,
                     providerURL: (window as any).solana,
@@ -76,8 +88,7 @@ export const multiwalletOptions = (
         moonbeam: [
             {
                 name: "Metamask",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
                 connector: new EthereumInjectedConnector({
                     debug: true,
                     networkIdMapper: () => RenNetwork.Testnet,
@@ -87,8 +98,7 @@ export const multiwalletOptions = (
         polygon: [
             {
                 name: "Metamask",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
                 connector: new EthereumInjectedConnector({
                     debug: true,
                     networkIdMapper: polygonNetworkToRenNetwork,
@@ -98,8 +108,7 @@ export const multiwalletOptions = (
         fantom: [
             {
                 name: "Metamask",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
                 connector: new EthereumInjectedConnector({
                     debug: true,
                     networkIdMapper: fantomNetworkToRenNetwork,
@@ -109,8 +118,7 @@ export const multiwalletOptions = (
         ethereum: [
             {
                 name: "Metamask",
-                logo:
-                    "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
+                logo: "https://avatars1.githubusercontent.com/u/11744586?s=60&v=4",
                 connector: new EthereumInjectedConnector({
                     debug: true,
                     networkIdMapper: ethNetworkToRenNetwork,
@@ -143,11 +151,10 @@ export const multiwalletOptions = (
              *     }),
              * }, */
         ],
-        bsc: [
+        binanceSmartChain: [
             {
                 name: "BinanceSmartWallet",
-                logo:
-                    "https://avatars2.githubusercontent.com/u/45615063?s=60&v=4",
+                logo: "https://avatars2.githubusercontent.com/u/45615063?s=60&v=4",
                 connector: new BinanceSmartChainInjectedConnector({
                     debug: true,
                 }),

--- a/packages/ui/playground/yarn.lock
+++ b/packages/ui/playground/yarn.lock
@@ -6768,10 +6768,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web3-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.4.0.tgz#e8cb381c81b242dc1d4ecb397200356d404410e6"
-  integrity sha512-b8mEhwh/J928Xk+SQFjtqrR2EGPhpknWLcIt9aCpVPVRXiqjUGo/kpOHKz0azu9c6/onEJ9tWXZt0cVjmH0N5Q==
+web3-utils@3.0.0-rc.5:
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-3.0.0-rc.5.tgz#f23fb03ee968f9cbbfdd50a5855759d968f2f4c9"
+  integrity sha512-TwYrNKXCrJJy7/ZRwZpipMf6Aq/ygsHbdvgXgCd/gJ18SYR9f8wn14zHHoZ8Xg7Sk3sDtf+A+lGPA6Y1mxzfGw==
   dependencies:
     bn.js "^4.11.9"
     eth-lib "0.2.8"

--- a/packages/ui/ren-react/package.json
+++ b/packages/ui/ren-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren-react",
-    "version": "2.4.5",
+    "version": "2.4.6-alpha.0",
     "description": "Easily create and track RenVM transactions in React",
     "keywords": [
         "renvm",
@@ -50,9 +50,9 @@
         "@babel/preset-react": "^7.10.1",
         "@babel/preset-typescript": "^7.13.0",
         "@open-wc/webpack-import-meta-loader": "^0.4.7",
-        "@renproject/chains-bitcoin": "^2.4.5",
-        "@renproject/chains-ethereum": "^2.4.5",
-        "@renproject/ren": "^2.4.5",
+        "@renproject/chains-bitcoin": "^2.4.6-alpha.0",
+        "@renproject/chains-ethereum": "^2.4.6-alpha.0",
+        "@renproject/ren": "^2.4.6-alpha.0",
         "@rollup/plugin-alias": "^3.1.1",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^18.0.0",

--- a/packages/ui/ren-react/src/library/Components/BurnAndReleaseComponents.tsx
+++ b/packages/ui/ren-react/src/library/Components/BurnAndReleaseComponents.tsx
@@ -29,7 +29,11 @@ const DefaultConfirmingBurn: React.FC<ConfirmingBurnProps> = ({
         <div className="confirmingBurn">
             Waiting for burn confirmation {confirmations}/
             {targetConfirmations || "?"}
-            {explorerLink && <a href={explorerLink}>Explorer Link</a>}
+            {explorerLink && (
+                <div>
+                    <a href={explorerLink}>Explorer Link</a>
+                </div>
+            )}
         </div>
     );
 };
@@ -91,10 +95,14 @@ const DefaultAcceptedBurn: React.FC<AcceptedBurnProps> = ({
         <div className="acceptedBurn">
             Burned {amount}
             {burnExplorerLink && (
-                <a href={burnExplorerLink}>Burn Explorer Link</a>
+                <div>
+                    <a href={burnExplorerLink}>Burn Explorer Link</a>
+                </div>
             )}
             {releaseExplorerLink && (
-                <a href={burnExplorerLink}>Release Explorer Link</a>
+                <div>
+                    <a href={burnExplorerLink}>Release Explorer Link</a>
+                </div>
             )}
         </div>
     );
@@ -116,7 +124,11 @@ const DefaultCompletedBurn: React.FC<CompletedBurnProps> = ({
         <div className="completed-burn">
             Successfully burned {amount}{" "}
             {txHash ? ` in release tx: ${txHash}` : ""}
-            {explorerLink && <a href={explorerLink}>Explorer Link</a>}
+            {explorerLink && (
+                <div>
+                    <a href={explorerLink}>Explorer Link</a>
+                </div>
+            )}
         </div>
     );
 };

--- a/packages/ui/ren-react/src/library/Components/LockAndMintComponents.tsx
+++ b/packages/ui/ren-react/src/library/Components/LockAndMintComponents.tsx
@@ -31,17 +31,20 @@ export interface ConfirmingDepositProps<X> {
     targetConfirmations?: number;
 }
 
-export const DefaultConfirmingDeposit: React.FC<
-    ConfirmingDepositProps<any>
-> = ({ confirmations, targetConfirmations, explorerLink }) => {
-    return (
-        <div className="confirmingDeposit">
-            Waiting for deposit confirmation {confirmations}/
-            {targetConfirmations || "?"}
-            {explorerLink && <a href={explorerLink}>Explorer Link</a>}
-        </div>
-    );
-};
+export const DefaultConfirmingDeposit: React.FC<ConfirmingDepositProps<any>> =
+    ({ confirmations, targetConfirmations, explorerLink }) => {
+        return (
+            <div className="confirmingDeposit">
+                Waiting for deposit confirmation {confirmations}/
+                {targetConfirmations || "?"}
+                {explorerLink && (
+                    <div>
+                        <a href={explorerLink}>Explorer Link</a>
+                    </div>
+                )}
+            </div>
+        );
+    };
 
 export interface SigningDepositProps {
     deposit: ConfirmingGatewayTransaction<any>;
@@ -55,13 +58,14 @@ export interface SubmittingMintDepositProps {
     deposit: SubmittingGatewayTransaction<any>;
 }
 
-export const DefaultSubmittingMintDeposit: React.FC<SubmittingMintDepositProps> = () => {
-    return (
-        <div className="submittingMint">
-            Please sign the transaction in your wallet
-        </div>
-    );
-};
+export const DefaultSubmittingMintDeposit: React.FC<SubmittingMintDepositProps> =
+    () => {
+        return (
+            <div className="submittingMint">
+                Please sign the transaction in your wallet
+            </div>
+        );
+    };
 
 export interface MintingDepositProps {
     deposit: SubmittingGatewayTransaction<any>;
@@ -103,7 +107,11 @@ export const DefaultCompletedDeposit: React.FC<CompletedDepositProps> = ({
     return (
         <div className="acceptedDeposit">
             Successfully minted {String(amount)}, tx: {String(tx)}
-            {explorerLink && <a href={explorerLink}>Explorer Link</a>}
+            {explorerLink && (
+                <div>
+                    <a href={explorerLink}>Explorer Link</a>
+                </div>
+            )}
         </div>
     );
 };
@@ -132,13 +140,14 @@ export interface ErrorRestoringDepositProps {
     reason: string;
 }
 
-export const DefaultErrorRestoringDeposit: React.FC<ErrorRestoringDepositProps> = ({
-    reason,
-}) => {
-    return (
-        <div className="errorRestoringDeposit">Error Restoring {reason}</div>
-    );
-};
+export const DefaultErrorRestoringDeposit: React.FC<ErrorRestoringDepositProps> =
+    ({ reason }) => {
+        return (
+            <div className="errorRestoringDeposit">
+                Error Restoring {reason}
+            </div>
+        );
+    };
 
 export interface ErrorMintingDepositProps {
     deposit: GatewayTransaction<any>;
@@ -245,7 +254,9 @@ export const DefaultDeposit: React.FC<DepositProps> = ({
             return (
                 <CompletedDeposit
                     deposit={deposit}
-                    amount={(deposit.renResponse?.out as any)?.amount}
+                    amount={formatAmount(
+                        (deposit.renResponse?.out as any)?.amount,
+                    )}
                     tx={deposit.destTxHash || ""}
                     explorerLink={mintExplorerLink}
                 />


### PR DESCRIPTION
Includes #150 

This fixes releasing LUNA and FIL from Solana. The chains did not support providing hex encoded bytes for release addresses, and as such was ignored.
