### PR TITLE
Fix support for Ethereum structs and tuples

### DIFF
--- a/packages/lib/chains/chains-filecoin/package.json
+++ b/packages/lib/chains/chains-filecoin/package.json
@@ -53,7 +53,8 @@
         "bignumber.js": "^9.0.1",
         "blakejs": "^1.1.0",
         "cids": "^1.1.6",
-        "elliptic": "^6.5.4"
+        "elliptic": "^6.5.4",
+        "lowercase-keys": "^2.0.0"
     },
     "resolutions": {
         "web-encoding": "^1.1.5"

--- a/packages/lib/chains/chains-solana/src/index.ts
+++ b/packages/lib/chains/chains-solana/src/index.ts
@@ -20,11 +20,9 @@ import {
     TransactionInstruction,
     SYSVAR_RENT_PUBKEY,
     SYSVAR_INSTRUCTIONS_PUBKEY,
-    Secp256k1Program,
     SystemProgram,
     sendAndConfirmRawTransaction,
     ConfirmOptions,
-    CreateSecp256k1InstructionWithPublicKeyParams,
     CreateSecp256k1InstructionWithEthAddressParams,
 } from "@solana/web3.js";
 import { TOKEN_PROGRAM_ID, Token } from "@solana/spl-token";
@@ -53,6 +51,7 @@ import {
 } from "./layouts";
 
 // FIXME: Typings are out of date, so lets fall back to good old any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ActualToken: any = Token;
 
 export type SolTransaction = string;
@@ -110,7 +109,7 @@ export class SolanaClass
         if (options) {
             this._logger = options.logger;
         }
-        this.initialize(this.renNetworkDetails!.name as RenNetwork);
+        this.initialize(this.renNetworkDetails.name).catch(console.error);
     }
 
     public static utils = {
@@ -161,6 +160,7 @@ export class SolanaClass
         },
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public utils = SolanaClass.utils as any;
 
     /**
@@ -223,6 +223,7 @@ export class SolanaClass
         return this._initialized;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     withProvider = (provider: any) => {
         this.provider = provider;
         return this;
@@ -416,7 +417,9 @@ export class SolanaClass
         await this.waitForInitialization();
         this._logger.debug("submitting mintTx:", mintTx);
         if (mintTx.out && mintTx.out.revert)
-            throw new Error("Transaction reverted: " + mintTx.out.revert);
+            throw new Error(
+                `Transaction reverted: ${mintTx.out.revert.toString()}`,
+            );
         if (!mintTx.out || !mintTx.out.signature)
             throw new Error("Missing signature");
         let sig = mintTx.out.signature;
@@ -696,8 +699,6 @@ export class SolanaClass
         );
 
         if (!gatewayInfo) throw new Error("incorrect gateway program address");
-
-        const gatewayState = GatewayLayout.decode(gatewayInfo.data);
 
         const s_hash = keccak256(Buffer.from(asset + "/toSolana"));
 

--- a/packages/lib/chains/chains-solana/src/networks.ts
+++ b/packages/lib/chains/chains-solana/src/networks.ts
@@ -76,7 +76,7 @@ export const renTestnet: SolNetworkConfig = {
     chain: "testnet",
     isTestnet: true,
     chainLabel: "Testnet",
-    endpoint: "https://testnet.solana.com",
+    endpoint: "https://api.testnet.solana.com",
     chainExplorer: "https://explorer.solana.com",
     lightnode: "https://lightnode-testnet.herokuapp.com",
     addresses: {

--- a/packages/lib/interfaces/src/ethArgs.ts
+++ b/packages/lib/interfaces/src/ethArgs.ts
@@ -1,3 +1,5 @@
+import { AbiInput } from "./abi";
+
 export type EthInt =
     | "int"
     | "int8"
@@ -108,7 +110,9 @@ export type EthType =
     | EthInt
     | EthUint
     | "byte"
-    | EthByte;
+    | EthByte
+    // Added to support tuples.
+    | string;
 
 export interface EthArg<
     name extends string = string,
@@ -119,6 +123,7 @@ export interface EthArg<
     name: name;
     type: type;
     value: valueType;
+    components?: AbiInput[];
 
     /**
      * `notInPayload` indicates that the parameter should be used when calling

--- a/yarn.lock
+++ b/yarn.lock
@@ -16145,6 +16145,11 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+
 lowlight@^1.14.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"


### PR DESCRIPTION
Web3 supports structs by passing them in as tuples - but it also expects a `components` array to be provided with a tuple. This PR adds a method to create this `components` array if it wasn't provided.