### PR TITLE
fix(arbitrum): restrict logs requested to 20000

### DIFF
--- a/packages/lib/chains/chains-ethereum/src/arbitrum.ts
+++ b/packages/lib/chains/chains-ethereum/src/arbitrum.ts
@@ -85,6 +85,8 @@ export class ArbitrumClass extends EthereumClass {
     public name = ArbitrumClass.chain;
     public legacyName = undefined;
 
+    public logRequestLimit = 20000;
+
     public static configMap = ArbitrumConfigMap;
     public configMap = ArbitrumConfigMap;
 

--- a/packages/lib/rpc/src/abstract.ts
+++ b/packages/lib/rpc/src/abstract.ts
@@ -130,6 +130,7 @@ export interface AbstractRenVMProvider<
     >(
         selector: string,
         utxoTxHash: Buffer,
+        retries?: number,
     ) => SyncOrPromise<T>;
 
     waitForTX: <T extends LockAndMintTransaction | BurnAndReleaseTransaction>(

--- a/packages/lib/rpc/src/combinedProvider.ts
+++ b/packages/lib/rpc/src/combinedProvider.ts
@@ -112,10 +112,11 @@ export class CombinedProvider
     >(
         selector: string,
         utxoTxHash: Buffer,
+        retries?: number,
     ): SyncOrPromise<T> =>
         this.v1 && isV1Selector(selector)
-            ? this.v1.queryMintOrBurn<T>(selector, utxoTxHash)
-            : this.v2.queryMintOrBurn<T>(selector, utxoTxHash);
+            ? this.v1.queryMintOrBurn<T>(selector, utxoTxHash, retries)
+            : this.v2.queryMintOrBurn<T>(selector, utxoTxHash, retries);
 
     waitForTX = <T extends LockAndMintTransaction | BurnAndReleaseTransaction>(
         selector: string,


### PR DESCRIPTION
Changelog:

* Limit the number of logs fetched from Arbitrum when looking up a mint to 20k logs