### PR TITLE
Fix: Add flag for excluding Solana payload

### DIFF
--- a/packages/lib/chains/chains-ethereum/package.json
+++ b/packages/lib/chains/chains-ethereum/package.json
@@ -43,14 +43,14 @@
         "prepare-release": "run-s npmignore build"
     },
     "dependencies": {
-        "@ethersproject/providers": "^5.4.3",
+        "@ethersproject/providers": "^5.4.4",
         "@renproject/interfaces": "^2.5.1",
         "@renproject/utils": "^2.5.1",
         "@types/bn.js": "^5.1.0",
         "@types/node": ">=10",
         "bignumber.js": "^9.0.1",
         "bn.js": "^5.2.0",
-        "ethers": "^5.4.3"
+        "ethers": "^5.4.5"
     },
     "resolutions": {
         "sha3": "^2.1.2"

--- a/packages/lib/chains/chains-solana/src/index.ts
+++ b/packages/lib/chains/chains-solana/src/index.ts
@@ -66,7 +66,8 @@ export interface SolanaProvider {
 }
 
 interface SolOptions {
-    logger: Logger;
+    logger?: Logger;
+    useEmptyPayload?: boolean;
 }
 
 export class SolanaClass
@@ -78,6 +79,7 @@ export class SolanaClass
 
     public renNetworkDetails: SolNetworkConfig;
     private _logger: Logger = new SimpleLogger();
+    private _useEmptyPayload: boolean = false;
 
     public burnPayloadConfig: BurnPayloadConfig = {
         bytes: false,
@@ -106,8 +108,11 @@ export class SolanaClass
         } else {
             this.renNetworkDetails = renMainnet;
         }
-        if (options) {
+        if (options && options.logger) {
             this._logger = options.logger;
+        }
+        if (options && options.useEmptyPayload) {
+            this._useEmptyPayload = true;
         }
         this.initialize(this.renNetworkDetails.name).catch(console.error);
     }
@@ -742,6 +747,7 @@ export class SolanaClass
                             name: "recipient",
                             type: "string",
                             value: recipient.toString(),
+                            notInPayload: this._useEmptyPayload,
                         },
                     ],
                 },

--- a/packages/lib/chains/chains-solana/src/index.ts
+++ b/packages/lib/chains/chains-solana/src/index.ts
@@ -67,7 +67,7 @@ export interface SolanaProvider {
 
 interface SolOptions {
     logger?: Logger;
-    useEmptyPayload?: boolean;
+    includeAddressInPayload?: boolean;
 }
 
 export class SolanaClass
@@ -79,7 +79,7 @@ export class SolanaClass
 
     public renNetworkDetails: SolNetworkConfig;
     private _logger: Logger = new SimpleLogger();
-    private _useEmptyPayload: boolean = false;
+    private _includeAddressInPayload: boolean = false;
 
     public burnPayloadConfig: BurnPayloadConfig = {
         bytes: false,
@@ -111,8 +111,8 @@ export class SolanaClass
         if (options && options.logger) {
             this._logger = options.logger;
         }
-        if (options && options.useEmptyPayload) {
-            this._useEmptyPayload = true;
+        if (options && options.includeAddressInPayload) {
+            this._includeAddressInPayload = true;
         }
         this.initialize(this.renNetworkDetails.name).catch(console.error);
     }
@@ -747,7 +747,7 @@ export class SolanaClass
                             name: "recipient",
                             type: "string",
                             value: recipient.toString(),
-                            notInPayload: this._useEmptyPayload,
+                            notInPayload: !this._includeAddressInPayload,
                         },
                     ],
                 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7822,9 +7822,9 @@ bitcoin-ops@^1.3.0:
   resolved "https://registry.yarnpkg.com/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
   integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
 
-"bitgo-utxo-lib@git+https://github.com/ren-forks/bitgo-utxo-lib.git#b848585e65b42c48b98c207e72d7d3006c9a5da0":
+"bitgo-utxo-lib@https://github.com/ren-forks/bitgo-utxo-lib#b848585e65b42c48b98c207e72d7d3006c9a5da0":
   version "1.9.1"
-  resolved "git+https://github.com/ren-forks/bitgo-utxo-lib.git#b848585e65b42c48b98c207e72d7d3006c9a5da0"
+  resolved "https://github.com/ren-forks/bitgo-utxo-lib#b848585e65b42c48b98c207e72d7d3006c9a5da0"
   dependencies:
     bech32 "0.0.3"
     bigi "^1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,7 +1687,7 @@
   dependencies:
     "@ethersproject/logger" "^5.4.0"
 
-"@ethersproject/providers@5.4.4", "@ethersproject/providers@^5.4.3":
+"@ethersproject/providers@5.4.4", "@ethersproject/providers@^5.4.4":
   version "5.4.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.4.tgz#6729120317942fc0ab0ecdb35e944ec6bbedb795"
   integrity sha512-mQevyXj2X2D3l8p/JGDYFZbODhZjW6On15DnCK4Xc9y6b+P0vqorQC/j46omWSm4cyo7BQ/rgfhXNYmvAfyZoQ==
@@ -12023,7 +12023,7 @@ ethers@4.0.0-beta.3:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.4.3:
+ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.4.3, ethers@^5.4.5:
   version "5.4.5"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.5.tgz#cec133b9f5b514dc55e2561ee7aa7218c33affd7"
   integrity sha512-PPZ6flOAj230sXEWf/r/It6ZZ5c7EOVWx+PU87Glkbg79OtT7pLE1WgL4MRdwx6iF7HzSOvUUI+8cAmcdzo12w==


### PR DESCRIPTION
A recent change affected payloads for Solana mints. This PR undoes that issue, but adds a flag so that existing mints can be handled properly.