### PR TITLE
fix(rentx): allow for retrying failed burn releases

### DIFF
--- a/packages/lib/ren-tx/src/machines/burn.ts
+++ b/packages/lib/ren-tx/src/machines/burn.ts
@@ -317,6 +317,9 @@ export const buildBurnMachine = <BurnType, ReleaseType>() =>
                             );
                         },
                     },
+                    on: {
+                        RETRY: "created",
+                    },
                 },
 
                 submittingBurn: {

--- a/packages/lib/ren-tx/src/machines/burn.ts
+++ b/packages/lib/ren-tx/src/machines/burn.ts
@@ -317,9 +317,14 @@ export const buildBurnMachine = <BurnType, ReleaseType>() =>
                             );
                         },
                     },
-                    on: {
-                        RETRY: "created",
-                    },
+                    // NOTE: this is sensitive; as a burn /might/ have been created,
+                    // but we have just failed to listen for the event.
+                    // It will always be safer to ask the user to check if funds have left
+                    // their wallet and start a new tx in this case
+                    //
+                    // on: {
+                    //     RETRY: "created",
+                    // },
                 },
 
                 submittingBurn: {

--- a/packages/lib/ren-tx/src/machines/burn.ts
+++ b/packages/lib/ren-tx/src/machines/burn.ts
@@ -131,9 +131,9 @@ export interface BurnMachineSchema {
 
 export type BurnMachineEvent<X, Y> =
     | { type: "NOOP" }
-    | { type: "RETRY" }
     | { type: "RESTORE" }
     | { type: "CREATED" }
+    | { type: "RETRY" }
     // Submit to renvm
     | { type: "SUBMIT" }
     // Burn Submitted
@@ -437,6 +437,9 @@ export const buildBurnMachine = <BurnType, ReleaseType>() =>
                             );
                         },
                     },
+                    on: {
+                        RETRY: "srcConfirmed",
+                    },
                 },
 
                 srcConfirmed: {
@@ -486,6 +489,8 @@ export const buildBurnMachine = <BurnType, ReleaseType>() =>
 
                 accepted: {
                     on: {
+                        // handle submitting to release chain
+                        SUBMIT: {},
                         RELEASE_ERROR: {
                             target: "errorReleasing",
                             actions: assign({


### PR DESCRIPTION
Currently, once the burn machine enters any error states, it cannot recover. This PR adds a "RETRY" event that will retry the release submission. RETRY is not available for errors with burn submission because it may lead to duplicate fund transfers