### PR TITLE
feat: add pack type bytes64

### DIFF
--- a/packages/utils/src/libraries/pack/binaryMarshal.ts
+++ b/packages/utils/src/libraries/pack/binaryMarshal.ts
@@ -58,6 +58,9 @@ export const encodePackType = (type: PackTypeDefinition): number => {
         // KindBytes65 is the kind of all 65-byte arrays.
         case PackPrimitive.Bytes65:
             return 13;
+        // KindBytes64 is the kind of all 64-byte arrays.
+        case PackPrimitive.Bytes64:
+            return 14;
     }
 
     // Complex types.
@@ -219,6 +222,7 @@ export const encodePackPrimitive = (
         }
         case PackPrimitive.Bytes32:
         case PackPrimitive.Bytes65:
+        case PackPrimitive.Bytes64:
             return value instanceof Uint8Array
                 ? value
                 : // Supports base64 url format

--- a/packages/utils/src/libraries/pack/types.ts
+++ b/packages/utils/src/libraries/pack/types.ts
@@ -14,6 +14,7 @@ export enum PackPrimitive {
     Bytes = "bytes",
     Bytes32 = "bytes32",
     Bytes65 = "bytes65",
+    Bytes64 = "bytes64",
 }
 
 export interface PackStructType<
@@ -68,6 +69,8 @@ export type Marshalled<
     ? string
     : Type extends PackPrimitive.Bytes65
     ? string
+    : Type extends PackPrimitive.Bytes64
+    ? string
     : Type extends PackNilType
     ? string
     : Type extends { list: InnerType }
@@ -100,6 +103,8 @@ export type Unmarshalled<
     : Type extends PackPrimitive.Bytes32
     ? Uint8Array
     : Type extends PackPrimitive.Bytes65
+    ? Uint8Array
+    : Type extends PackPrimitive.Bytes64
     ? Uint8Array
     : Type extends PackNilType
     ? null

--- a/packages/utils/src/libraries/pack/unmarshal.ts
+++ b/packages/utils/src/libraries/pack/unmarshal.ts
@@ -42,6 +42,7 @@ export const unmarshalPackPrimitive = <T extends PackPrimitive = PackPrimitive>(
         case PackPrimitive.Bytes:
         case PackPrimitive.Bytes32:
         case PackPrimitive.Bytes65:
+        case PackPrimitive.Bytes64:
             return utils.fromBase64(value) as Unmarshalled<T>;
     }
     throw new Error(`Unknown pack type '${type}'.`);


### PR DESCRIPTION
See https://github.com/renproject/pack/pull/12 - _Add bytes64 type for use with schnorr signatures_