### PR TITLE
Fix: Solana `numRequiredSignatures` error

### DIFF
--- a/packages/chains/chains-solana/src/solanaTxSubmitter.ts
+++ b/packages/chains/chains-solana/src/solanaTxSubmitter.ts
@@ -178,7 +178,10 @@ export class SolanaTxWaiter
 
             // sendAndConfirmRawTransaction already calls simulate.
             const simulationResult = await utils.tryNTimes(
-                async () => this._provider.simulateTransaction(transaction),
+                async () =>
+                    this._provider.simulateTransaction(
+                        transaction.compileMessage(),
+                    ),
                 5,
             );
             if (simulationResult.value.err) {


### PR DESCRIPTION
The solana connector was throwing `Cannot read properties of undefined (reading 'numRequiredSignatures')` when passing a Transaction to `simulateTransaction`, so this fix first calls `tx.compileMessage()`