### PR TITLE
Release 3.5.0: Require `defaultTestnet` Ethereum flag, Moonbeam mainnet config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ yarn link @renproject/ren @renproject/chains @renproject/utils @renproject/provi
 
 You'll need to:
 
-1. Generate a mnemonic and send ETH (kovan for testnet) (path: `m/44'/60'/0'/0/`).
+1. Generate a mnemonic and send ETH (goerli for testnet) (path: `m/44'/60'/0'/0/`).
     - `let w = require("ethers").Wallet.createRandom(); console.debug(w.address, w.mnemonic.phrase);`
 2. Generate a private key and send testnet crypto funds.
     - `require("send-crypto").newPrivateKey();`

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "3.5.0"
+    "version": "3.4.5"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "3.4.5"
+    "version": "3.5.0"
 }

--- a/packages/chains/chains-bitcoin/package.json
+++ b/packages/chains/chains-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-bitcoin",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "@noble/hashes": "1.1.2",
-        "@renproject/utils": "^3.4.5",
+        "@renproject/utils": "^3.5.0",
         "@types/bchaddrjs": "0.4.0",
         "@types/bs58": "4.0.1",
         "@types/bs58check": "2.1.0",

--- a/packages/chains/chains-bitcoin/package.json
+++ b/packages/chains/chains-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-bitcoin",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "@noble/hashes": "1.1.2",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.4.5",
         "@types/bchaddrjs": "0.4.0",
         "@types/bs58": "4.0.1",
         "@types/bs58check": "2.1.0",

--- a/packages/chains/chains-bitcoin/src/base.ts
+++ b/packages/chains/chains-bitcoin/src/base.ts
@@ -362,6 +362,19 @@ export abstract class BitcoinBaseChain
         );
     };
 
+    public populateChainTransaction = (
+        partialTx: Partial<ChainTransaction> &
+            ({ txid: string } | { txHash: string }),
+    ): ChainTransaction => {
+        return populateChainTransaction({
+            partialTx,
+            chain: this.chain,
+            txHashToBytes,
+            txHashFromBytes,
+            explorerLink: this.transactionExplorerLink,
+        });
+    };
+
     // Methods for initializing mints and burns ////////////////////////////////
 
     /**
@@ -423,13 +436,7 @@ export abstract class BitcoinBaseChain
             chain: this.chain,
             type: "transaction",
             params: {
-                tx: populateChainTransaction({
-                    partialTx,
-                    chain: this.chain,
-                    txHashToBytes,
-                    txHashFromBytes,
-                    explorerLink: this.transactionExplorerLink,
-                }),
+                tx: this.populateChainTransaction(partialTx),
             },
         };
     };

--- a/packages/chains/chains-bitcoin/src/utils/types.ts
+++ b/packages/chains/chains-bitcoin/src/utils/types.ts
@@ -1,8 +1,4 @@
-import {
-    ChainTransaction,
-    RenNetwork,
-    RenNetworkString,
-} from "@renproject/utils";
+import { ChainTransaction, RenNetwork } from "@renproject/utils";
 
 import { APIWithPriority, BitcoinAPI } from "../APIs/API";
 
@@ -65,5 +61,5 @@ export type BitcoinNetworkConfigMap = {
 
 export type BitcoinNetworkInput =
     | RenNetwork
-    | RenNetworkString
+    | `${RenNetwork}`
     | BitcoinNetworkConfig;

--- a/packages/chains/chains-ethereum/package.json
+++ b/packages/chains/chains-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-ethereum",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,7 +45,7 @@
         "@ethersproject/abi": "5.6.4",
         "@ethersproject/bytes": "5.6.1",
         "@ethersproject/providers": "5.6.8",
-        "@renproject/utils": "^3.4.5",
+        "@renproject/utils": "^3.5.0",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/chains/chains-ethereum/package.json
+++ b/packages/chains/chains-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-ethereum",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,7 +45,7 @@
         "@ethersproject/abi": "5.6.4",
         "@ethersproject/bytes": "5.6.1",
         "@ethersproject/providers": "5.6.8",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.4.5",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/chains/chains-ethereum/src/base.ts
+++ b/packages/chains/chains-ethereum/src/base.ts
@@ -1262,6 +1262,20 @@ export class EthereumBaseChain
         };
     };
 
+    public populateChainTransaction = (
+        partialTx: Partial<ChainTransaction> &
+            ({ txid: string } | { txHash: string }),
+    ): ChainTransaction => {
+        return populateChainTransaction({
+            partialTx,
+            chain: this.chain,
+            txHashToBytes,
+            txHashFromBytes,
+            defaultTxindex: "0",
+            explorerLink: this.transactionExplorerLink,
+        });
+    };
+
     /* ====================================================================== */
 
     public Account = ({
@@ -1452,14 +1466,7 @@ export class EthereumBaseChain
             chain: this.chain,
             type: "transaction",
             params: {
-                tx: populateChainTransaction({
-                    partialTx,
-                    chain: this.chain,
-                    txHashToBytes,
-                    txHashFromBytes,
-                    defaultTxindex: "0",
-                    explorerLink: this.transactionExplorerLink,
-                }),
+                tx: this.populateChainTransaction(partialTx),
             },
             payloadConfig,
         };

--- a/packages/chains/chains-ethereum/src/ethereum.ts
+++ b/packages/chains/chains-ethereum/src/ethereum.ts
@@ -108,6 +108,41 @@ export enum EthereumTestnet {
     Kovan = "kovan",
 }
 
+const defaultAssets = {
+    ETH: "ETH" as const,
+    DAI: "DAI" as const,
+    REN: "REN" as const,
+    USDC: "USDC" as const,
+    USDT: "USDT" as const,
+    EURT: "EURT" as const,
+    BUSD: "BUSD" as const,
+    MIM: "MIM" as const,
+    CRV: "CRV" as const,
+    LINK: "LINK" as const,
+    UNI: "UNI" as const,
+    SUSHI: "SUSHI" as const,
+    FTT: "FTT" as const,
+    ROOK: "ROOK" as const,
+    BADGER: "BADGER" as const,
+    KNC: "KNC" as const,
+};
+
+const goerliAssets = {
+    ETH: "gETH" as const,
+    DAI: "DAI_Goerli" as const,
+    REN: "REN_Goerli" as const,
+    USDC: "USDC_Goerli" as const,
+    USDT: "USDT_Goerli" as const,
+
+    // Goerli only
+    gETH: "gETH" as const,
+    REN_Goerli: "REN_Goerli" as const,
+    DAI_Goerli: "DAI_Goerli" as const,
+    USDC_Goerli: "USDC_Goerli" as const,
+    USDT_Goerli: "USDT_Goerli" as const,
+    ETH_Goerli: "gETH" as const,
+};
+
 /**
  * The Ethereum RenJS implementation.
  */
@@ -116,32 +151,8 @@ export class Ethereum extends EthereumBaseChain {
     public static chain = "Ethereum" as const;
     public static configMap = defaultConfigMap;
     public static assets = {
-        ETH: "ETH" as const,
-        DAI: "DAI" as const,
-        REN: "REN" as const,
-        USDC: "USDC" as const,
-        USDT: "USDT" as const,
-        EURT: "EURT" as const,
-        BUSD: "BUSD" as const,
-        MIM: "MIM" as const,
-        CRV: "CRV" as const,
-        LINK: "LINK" as const,
-        UNI: "UNI" as const,
-        SUSHI: "SUSHI" as const,
-        FTT: "FTT" as const,
-        ROOK: "ROOK" as const,
-        BADGER: "BADGER" as const,
-        KNC: "KNC" as const,
-
-        // Goerli only
-        gETH: "gETH" as const,
-        REN_Goerli: "REN_Goerli" as const,
-        DAI_Goerli: "DAI_Goerli" as const,
-        USDC_Goerli: "USDC_Goerli" as const,
-        USDT_Goerli: "USDT_Goerli" as const,
-
-        // Aliases
-        ETH_Goerli: "gETH" as const,
+        ...goerliAssets,
+        ...defaultAssets,
     };
 
     public configMap = Ethereum.configMap;
@@ -177,5 +188,11 @@ export class Ethereum extends EthereumBaseChain {
             defaultTestnet === EthereumTestnet.Görli
                 ? goerliConfigMap
                 : defaultConfigMap;
+        this.assets = (
+            defaultTestnet === EthereumTestnet.Görli &&
+            network === RenNetwork.Testnet
+                ? goerliAssets
+                : defaultAssets
+        ) as typeof this.assets;
     }
 }

--- a/packages/chains/chains-ethereum/src/ethereum.ts
+++ b/packages/chains/chains-ethereum/src/ethereum.ts
@@ -102,6 +102,12 @@ export const goerliConfigMap: EthereumBaseChain["configMap"] = {
     [RenNetwork.Testnet]: goerliConfig,
 };
 
+export enum EthereumTestnet {
+    Goerli = "goerli",
+    Görli = "goerli",
+    Kovan = "kovan",
+}
+
 /**
  * The Ethereum RenJS implementation.
  */
@@ -153,19 +159,23 @@ export class Ethereum extends EthereumBaseChain {
      */
     public constructor({
         network,
-        testnet,
+        defaultTestnet,
         ...params
     }: ConstructorParameters<typeof EthereumBaseChain>[0] & {
-        testnet?: "Kovan" | "Goerli" | "Görli";
+        defaultTestnet: EthereumTestnet | `${EthereumTestnet}`;
     }) {
         super({
             ...params,
             network: resolveEVMNetworkConfig(
-                testnet === "Goerli" || testnet === "Görli"
+                defaultTestnet === EthereumTestnet.Görli
                     ? goerliConfigMap
                     : defaultConfigMap,
                 network,
             ),
         });
+        this.configMap =
+            defaultTestnet === EthereumTestnet.Görli
+                ? goerliConfigMap
+                : defaultConfigMap;
     }
 }

--- a/packages/chains/chains-ethereum/src/goerli.ts
+++ b/packages/chains/chains-ethereum/src/goerli.ts
@@ -1,5 +1,5 @@
 import { EthereumBaseChain } from "./base";
-import { goerliConfigMap } from "./ethereum";
+import { EthereumTestnet, goerliConfigMap } from "./ethereum";
 import { resolveEVMNetworkConfig } from "./utils/generic";
 
 export class Goerli extends EthereumBaseChain {
@@ -15,6 +15,11 @@ export class Goerli extends EthereumBaseChain {
 
         // Aliases
         ETH: "gETH" as const,
+        ETH_Goerli: "gETH" as const,
+        REN_Goerli: "REN_Goerli" as const,
+        DAI_Goerli: "DAI_Goerli" as const,
+        USDC_Goerli: "USDC_Goerli" as const,
+        USDT_Goerli: "USDT_Goerli" as const,
     };
 
     public configMap = goerliConfigMap;
@@ -23,7 +28,9 @@ export class Goerli extends EthereumBaseChain {
     public constructor({
         network,
         ...params
-    }: ConstructorParameters<typeof EthereumBaseChain>[0]) {
+    }: ConstructorParameters<typeof EthereumBaseChain>[0] & {
+        defaultTestnet?: EthereumTestnet.Goerli | `${EthereumTestnet.Goerli}`;
+    }) {
         super({
             ...params,
             network: resolveEVMNetworkConfig(goerliConfigMap, network),

--- a/packages/chains/chains-ethereum/src/moonbeam.ts
+++ b/packages/chains/chains-ethereum/src/moonbeam.ts
@@ -15,14 +15,16 @@ const configMap: EthereumBaseChain["configMap"] = {
             chainId: "0x504",
             chainName: "Moonbeam",
             nativeCurrency: { name: "Glimmer", symbol: "GLMR", decimals: 18 },
-            rpcUrls: ["https://rpc.api.moonbeam.network"],
+            rpcUrls: [
+                "https://rpc.api.moonbeam.network",
+                "wss://wss.api.moonbeam.network",
+            ],
             blockExplorerUrls: ["https://moonbeam.moonscan.io"],
         },
 
         addresses: {
-            // TODO: Fill out once available.
-            GatewayRegistry: "",
-            BasicBridge: "",
+            GatewayRegistry: "0xf36666C230Fa12333579b9Bd6196CB634D6BC506",
+            BasicBridge: "0x82DF02A52E2e76C0c233367f2fE6c9cfe51578c5",
         },
     },
 

--- a/packages/chains/chains-ethereum/src/utils/types.ts
+++ b/packages/chains/chains-ethereum/src/utils/types.ts
@@ -3,7 +3,7 @@ import {
     ExternalProvider,
     JsonRpcFetchFunc,
 } from "@ethersproject/providers/lib/web3-provider";
-import { Logger, RenNetwork, RenNetworkString } from "@renproject/utils";
+import { Logger, RenNetwork } from "@renproject/utils";
 import { ethers } from "ethers";
 
 export interface EVMExplorer {
@@ -69,7 +69,7 @@ export interface EVMNetworkConfig {
         BasicBridge: string;
     };
 
-    // See EVMNetworkConfig.network.nativeCurrency
+    // Allow overriding values from EVMNetworkConfig.config.nativeCurrency
     nativeAsset: {
         name: string;
         symbol: string;
@@ -80,7 +80,7 @@ export interface EVMNetworkConfig {
     config: EIP3085Config;
 }
 
-export type EVMNetworkInput = RenNetwork | RenNetworkString | EVMNetworkConfig;
+export type EVMNetworkInput = RenNetwork | `${RenNetwork}` | EVMNetworkConfig;
 export type EvmNetworkInput = EVMNetworkInput;
 
 export type EthProvider =

--- a/packages/chains/chains-ethereum/test/initialization.spec.ts
+++ b/packages/chains/chains-ethereum/test/initialization.spec.ts
@@ -1,0 +1,39 @@
+/* eslint-disable no-console */
+
+import { RenNetwork } from "@renproject/utils";
+import chai, { expect } from "chai";
+import { config as loadDotEnv } from "dotenv";
+
+import { Ethereum } from "../src/ethereum";
+
+loadDotEnv();
+
+chai.should();
+
+describe("Initialization", () => {
+    it("Initialize with correct testnet", async () => {
+        const mainnet = new Ethereum({
+            network: RenNetwork.Mainnet,
+            provider: "",
+            defaultTestnet: "goerli",
+        });
+
+        expect(mainnet.configMap.mainnet.selector).to.equal("Ethereum");
+
+        const kovan = new Ethereum({
+            network: RenNetwork.Testnet,
+            provider: "",
+            defaultTestnet: "kovan",
+        });
+
+        expect(kovan.configMap.testnet.selector).to.equal("Ethereum");
+
+        const goerli = new Ethereum({
+            network: RenNetwork.Testnet,
+            provider: "",
+            defaultTestnet: "goerli",
+        });
+
+        expect(goerli.configMap.testnet.selector).to.equal("Goerli");
+    });
+});

--- a/packages/chains/chains-ethereum/test/initialization.spec.ts
+++ b/packages/chains/chains-ethereum/test/initialization.spec.ts
@@ -19,6 +19,7 @@ describe("Initialization", () => {
         });
 
         expect(mainnet.configMap.mainnet.selector).to.equal("Ethereum");
+        expect(mainnet.assets.ETH).to.equal("ETH");
 
         const kovan = new Ethereum({
             network: RenNetwork.Testnet,
@@ -27,6 +28,7 @@ describe("Initialization", () => {
         });
 
         expect(kovan.configMap.testnet.selector).to.equal("Ethereum");
+        expect(kovan.assets.ETH).to.equal("ETH");
 
         const goerli = new Ethereum({
             network: RenNetwork.Testnet,
@@ -35,5 +37,6 @@ describe("Initialization", () => {
         });
 
         expect(goerli.configMap.testnet.selector).to.equal("Goerli");
+        expect(goerli.assets.ETH).to.equal("gETH");
     });
 });

--- a/packages/chains/chains-filecoin/package.json
+++ b/packages/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -44,7 +44,7 @@
     "dependencies": {
         "@glif/filecoin-address": "1.1.0",
         "@glif/filecoin-rpc-client": "1.1.0",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.4.5",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "blakejs": "1.2.1",

--- a/packages/chains/chains-filecoin/package.json
+++ b/packages/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -44,7 +44,7 @@
     "dependencies": {
         "@glif/filecoin-address": "1.1.0",
         "@glif/filecoin-rpc-client": "1.1.0",
-        "@renproject/utils": "^3.4.5",
+        "@renproject/utils": "^3.5.0",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "blakejs": "1.2.1",

--- a/packages/chains/chains-filecoin/src/filecoin.ts
+++ b/packages/chains/chains-filecoin/src/filecoin.ts
@@ -17,7 +17,6 @@ import {
     populateChainTransaction,
     RenJSError,
     RenNetwork,
-    RenNetworkString,
     utils,
 } from "@renproject/utils";
 import BigNumber from "bignumber.js";
@@ -149,7 +148,7 @@ export class Filecoin
         network,
         options,
     }: {
-        network: RenNetwork | RenNetworkString | FilecoinNetworkConfig;
+        network: RenNetwork | `${RenNetwork}` | FilecoinNetworkConfig;
         options?: FilecoinConfig;
     }) {
         const networkConfig = isFilecoinNetworkConfig(network)
@@ -572,6 +571,20 @@ export class Filecoin
         };
     };
 
+    public populateChainTransaction = (
+        partialTx: Partial<ChainTransaction> &
+            ({ txid: string } | { txHash: string }),
+    ): ChainTransaction => {
+        return populateChainTransaction({
+            partialTx,
+            chain: this.chain,
+            txHashToBytes,
+            txHashFromBytes,
+            defaultTxindex: "0",
+            explorerLink: this.transactionExplorerLink,
+        });
+    };
+
     // Methods for initializing mints and burns ////////////////////////////////
 
     /**
@@ -629,14 +642,7 @@ export class Filecoin
             chain: this.chain,
             type: "transaction",
             params: {
-                tx: populateChainTransaction({
-                    partialTx,
-                    chain: this.chain,
-                    txHashToBytes,
-                    txHashFromBytes,
-                    defaultTxindex: "0",
-                    explorerLink: this.transactionExplorerLink,
-                }),
+                tx: this.populateChainTransaction(partialTx),
             },
         };
     };

--- a/packages/chains/chains-solana/package.json
+++ b/packages/chains/chains-solana/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-solana",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.4.5",
         "@scure/bip39": "1.1.0",
         "@solana/spl-token": "0.2.0",
         "@solana/web3.js": "1.50.1",

--- a/packages/chains/chains-solana/package.json
+++ b/packages/chains/chains-solana/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-solana",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.4.5",
+        "@renproject/utils": "^3.5.0",
         "@scure/bip39": "1.1.0",
         "@solana/spl-token": "0.2.0",
         "@solana/web3.js": "1.50.1",

--- a/packages/chains/chains-solana/src/networks.ts
+++ b/packages/chains/chains-solana/src/networks.ts
@@ -1,4 +1,4 @@
-import { RenNetwork, RenNetworkString } from "@renproject/utils";
+import { RenNetwork } from "@renproject/utils";
 
 export interface SolNetworkConfig {
     name: RenNetwork;
@@ -27,7 +27,7 @@ const isSolNetworkConfig = (x: unknown): x is SolNetworkConfig =>
     (x as SolNetworkConfig).genesisHash !== undefined;
 
 export const resolveNetwork = (
-    networkInput: RenNetwork | RenNetworkString | SolNetworkConfig,
+    networkInput: RenNetwork | `${RenNetwork}` | SolNetworkConfig,
 ): SolNetworkConfig => {
     if (typeof networkInput === "string") {
         switch (networkInput) {

--- a/packages/chains/chains-solana/src/solana.ts
+++ b/packages/chains/chains-solana/src/solana.ts
@@ -11,7 +11,6 @@ import {
     OutputType,
     populateChainTransaction,
     RenNetwork,
-    RenNetworkString,
     TxSubmitter,
     TxWaiter,
     utils,
@@ -82,7 +81,7 @@ export class Solana
         signer,
         config,
     }: {
-        network: RenNetwork | RenNetworkString | SolNetworkConfig;
+        network: RenNetwork | `${RenNetwork}` | SolNetworkConfig;
         provider?: Connection | string;
         signer?: Wallet;
         config?: SolOptions;
@@ -1131,6 +1130,22 @@ export class Solana
         });
     };
 
+    public populateChainTransaction = (
+        partialTx: Partial<ChainTransaction> &
+            ({ txid: string } | { txHash: string }),
+    ): ChainTransaction => {
+        return populateChainTransaction({
+            partialTx,
+            chain: this.chain,
+            txHashToBytes,
+            txHashFromBytes,
+            defaultTxindex: "0",
+            explorerLink: this.transactionExplorerLink,
+        });
+    };
+
+    /* ====================================================================== */
+
     public Account = ({
         amount,
         convertUnit,
@@ -1205,14 +1220,7 @@ export class Solana
             chain: this.chain,
             type: "transaction",
             params: {
-                tx: populateChainTransaction({
-                    partialTx,
-                    chain: this.chain,
-                    txHashToBytes,
-                    txHashFromBytes,
-                    defaultTxindex: "0",
-                    explorerLink: this.transactionExplorerLink,
-                }),
+                tx: this.populateChainTransaction(partialTx),
             },
         };
     };

--- a/packages/chains/chains-terra/package.json
+++ b/packages/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.4.5",
         "@terra-money/terra.js": "3.1.5",
         "@types/elliptic": "6.4.14",
         "bech32": "2.0.0",

--- a/packages/chains/chains-terra/package.json
+++ b/packages/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.4.5",
+        "@renproject/utils": "^3.5.0",
         "@terra-money/terra.js": "3.1.5",
         "@types/elliptic": "6.4.14",
         "bech32": "2.0.0",

--- a/packages/chains/chains-terra/src/terra.ts
+++ b/packages/chains/chains-terra/src/terra.ts
@@ -9,7 +9,6 @@ import {
     populateChainTransaction,
     RenJSError,
     RenNetwork,
-    RenNetworkString,
     utils,
 } from "@renproject/utils";
 import { AccAddress, SimplePublicKey } from "@terra-money/terra.js";
@@ -174,7 +173,7 @@ export class Terra
     public constructor({
         network,
     }: {
-        network: RenNetwork | RenNetworkString | TerraNetworkConfig;
+        network: RenNetwork | `${RenNetwork}` | TerraNetworkConfig;
     }) {
         const networkConfig = isTerraNetworkConfig(network)
             ? network
@@ -359,6 +358,19 @@ export class Terra
         };
     };
 
+    public populateChainTransaction = (
+        partialTx: Partial<ChainTransaction> &
+            ({ txid: string } | { txHash: string }),
+    ): ChainTransaction => {
+        return populateChainTransaction({
+            partialTx,
+            chain: this.chain,
+            txHashToBytes,
+            txHashFromBytes,
+            explorerLink: this.transactionExplorerLink,
+        });
+    };
+
     // Methods for initializing mints and burns ////////////////////////////////
 
     /**
@@ -418,13 +430,7 @@ export class Terra
             chain: this.chain,
             type: "transaction",
             params: {
-                tx: populateChainTransaction({
-                    partialTx,
-                    chain: this.chain,
-                    txHashToBytes,
-                    txHashFromBytes,
-                    explorerLink: this.transactionExplorerLink,
-                }),
+                tx: this.populateChainTransaction(partialTx),
             },
         };
     };

--- a/packages/chains/chains/package.json
+++ b/packages/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,12 +42,12 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^3.5.0",
-        "@renproject/chains-ethereum": "^3.5.0",
-        "@renproject/chains-filecoin": "^3.5.0",
-        "@renproject/chains-solana": "^3.5.0",
-        "@renproject/chains-terra": "^3.5.0",
-        "@renproject/utils": "^3.5.0"
+        "@renproject/chains-bitcoin": "^3.4.5",
+        "@renproject/chains-ethereum": "^3.4.5",
+        "@renproject/chains-filecoin": "^3.4.5",
+        "@renproject/chains-solana": "^3.4.5",
+        "@renproject/chains-terra": "^3.4.5",
+        "@renproject/utils": "^3.4.5"
     },
     "nyc": {
         "extends": "@istanbuljs/nyc-config-typescript",

--- a/packages/chains/chains/package.json
+++ b/packages/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,12 +42,12 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^3.4.5",
-        "@renproject/chains-ethereum": "^3.4.5",
-        "@renproject/chains-filecoin": "^3.4.5",
-        "@renproject/chains-solana": "^3.4.5",
-        "@renproject/chains-terra": "^3.4.5",
-        "@renproject/utils": "^3.4.5"
+        "@renproject/chains-bitcoin": "^3.5.0",
+        "@renproject/chains-ethereum": "^3.5.0",
+        "@renproject/chains-filecoin": "^3.5.0",
+        "@renproject/chains-solana": "^3.5.0",
+        "@renproject/chains-terra": "^3.5.0",
+        "@renproject/utils": "^3.5.0"
     },
     "nyc": {
         "extends": "@istanbuljs/nyc-config-typescript",

--- a/packages/mock-provider/package.json
+++ b/packages/mock-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/mock-provider",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^3.5.0",
-        "@renproject/provider": "^3.5.0",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/chains-bitcoin": "^3.4.5",
+        "@renproject/provider": "^3.4.5",
+        "@renproject/utils": "^3.4.5",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/mock-provider/package.json
+++ b/packages/mock-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/mock-provider",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^3.4.5",
-        "@renproject/provider": "^3.4.5",
-        "@renproject/utils": "^3.4.5",
+        "@renproject/chains-bitcoin": "^3.5.0",
+        "@renproject/provider": "^3.5.0",
+        "@renproject/utils": "^3.5.0",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/provider",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "description": "Official Ren JavaScript client",
     "repository": {
         "type": "git",
@@ -43,7 +43,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.4.5",
+        "@renproject/utils": "^3.5.0",
         "axios": "0.27.2",
         "bignumber.js": "9.0.2"
     },

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/provider",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "description": "Official Ren JavaScript client",
     "repository": {
         "type": "git",
@@ -43,7 +43,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.4.5",
         "axios": "0.27.2",
         "bignumber.js": "9.0.2"
     },

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -6,7 +6,6 @@ import {
     pack,
     RenJSError,
     RenNetwork,
-    RenNetworkString,
     RenVMShard,
     TxStatus,
     utils,
@@ -123,7 +122,7 @@ export class RenVMProvider extends JsonRpcProvider<RPCParams, RPCResponses> {
     public constructor(
         endpointOrProvider:
             | RenNetwork
-            | RenNetworkString
+            | `${RenNetwork}`
             | string
             | Provider<RPCParams, RPCResponses>,
         logger: Logger = defaultLogger,

--- a/packages/ren/package.json
+++ b/packages/ren/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "description": "Official Ren JavaScript SDK for bridging crypto assets cross-chain.",
     "repository": {
         "type": "git",
@@ -56,8 +56,8 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/provider": "^3.4.5",
-        "@renproject/utils": "^3.4.5",
+        "@renproject/provider": "^3.5.0",
+        "@renproject/utils": "^3.5.0",
         "bignumber.js": "9.0.2",
         "events": "3.3.0",
         "immutable": "4.1.0"

--- a/packages/ren/package.json
+++ b/packages/ren/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "description": "Official Ren JavaScript SDK for bridging crypto assets cross-chain.",
     "repository": {
         "type": "git",
@@ -56,8 +56,8 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/provider": "^3.5.0",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/provider": "^3.4.5",
+        "@renproject/utils": "^3.4.5",
         "bignumber.js": "9.0.2",
         "events": "3.3.0",
         "immutable": "4.1.0"

--- a/packages/ren/src/index.ts
+++ b/packages/ren/src/index.ts
@@ -5,7 +5,6 @@ import {
     ErrorWithCode,
     RenJSError,
     RenNetwork,
-    RenNetworkString,
     RenVMShard,
 } from "@renproject/utils";
 
@@ -98,7 +97,7 @@ export class RenJS {
     public constructor(
         providerOrNetwork:
             | RenNetwork
-            | RenNetworkString
+            | `${RenNetwork}`
             | RenVMProvider
             | string = RenNetwork.Mainnet,
         config?: RenJSConfig,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/utils",
-    "version": "3.5.0",
+    "version": "3.4.5",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/utils",
-    "version": "3.4.5",
+    "version": "3.5.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/utils/src/types/chain.ts
+++ b/packages/utils/src/types/chain.ts
@@ -153,6 +153,11 @@ export interface ChainCommon {
     //     tx: ChainTransaction,
     //     target?: number,
     // ) => SyncOrPromise<TxWaiter>;
+
+    populateChainTransaction: (
+        partialTx: Partial<ChainTransaction> &
+            ({ txid: string } | { txHash: string }),
+    ) => ChainTransaction;
 }
 
 export interface DepositChain<

--- a/packages/utils/src/types/renNetwork.ts
+++ b/packages/utils/src/types/renNetwork.ts
@@ -4,4 +4,4 @@ export enum RenNetwork {
     Devnet = "devnet",
 }
 
-export type RenNetworkString = "mainnet" | "testnet" | "devnet";
+export type RenNetworkString = `${RenNetwork}`;

--- a/packages/utils/test/common.spec.ts
+++ b/packages/utils/test/common.spec.ts
@@ -183,13 +183,27 @@ describe("common utils", () => {
             ).to.equal(2);
             expect(logged).to.equal(true);
 
-            await expect(
-                utils.tryNTimes(mustBeCalledNTimes(2), 1, 0),
-            ).to.be.rejectedWith("Only called 1/2 times");
+            expect(
+                await new Promise<string>((resolve, reject) => {
+                    utils
+                        .tryNTimes(mustBeCalledNTimes(2), 1, 0)
+                        .then(() =>
+                            reject(new Error(`Line should have thrown.`)),
+                        )
+                        .catch((error) => resolve(error.message));
+                }),
+            ).to.equal("Only called 1/2 times");
 
-            await expect(
-                utils.tryNTimes(mustBeCalledNTimes(2, true), 1, 0),
-            ).to.be.rejectedWith("Only called 1/2 times");
+            expect(
+                await new Promise<string>((resolve, reject) => {
+                    utils
+                        .tryNTimes(mustBeCalledNTimes(2, true), 1, 0)
+                        .then(() =>
+                            reject(new Error(`Line should have thrown.`)),
+                        )
+                        .catch((error) => resolve(error.message));
+                }),
+            ).to.equal("Only called 1/2 times");
         });
 
         it("should use provided timeout", async () => {

--- a/test/gateway.spec.ts
+++ b/test/gateway.spec.ts
@@ -16,7 +16,6 @@ import {
     Polygon,
 } from "packages/chains/chains-ethereum/src";
 import { Filecoin } from "packages/chains/chains-filecoin/src";
-import { Terra } from "packages/chains/chains-terra/src";
 import RenJS from "packages/ren/src";
 import { GatewayParams } from "packages/ren/src/params";
 import { RenNetwork } from "packages/utils/src";
@@ -57,11 +56,11 @@ describe("Gateway", () => {
     //     console.info(burnLogs[0]);
     // });
 
-    it.skip("recover", async () => {
+    it("recover", async () => {
         const network = RenNetwork.Mainnet;
-        const asset = Terra.assets.LUNA;
-        const from = initializeChain(Polygon, network);
-        const to = initializeChain(Terra, network, {
+        const asset = Ethereum.assets.ETH;
+        const from = initializeChain(Ethereum, network);
+        const to = initializeChain(Catalog, network, {
             preserveAddressFormat: true,
         });
         const renJS = new RenJS(network).withChains(from, to);
@@ -69,9 +68,25 @@ describe("Gateway", () => {
         const gatewayParams: GatewayParams = {
             asset,
             from: from.Transaction({
-                txHash: "0x112e09e083ca35a084799736d949e30271965000a6903565a6408857afee9cad",
+                txHash: "0xc46b1a9a44c1a7041988100d0836d2e1837200ec35c82ff45ad8a7c501e23121",
             }),
-            to: to.Address("terra1dqfxvrt23pftru924w0mxjv3vnjzzf35mp7g24"),
+            to: to.Contract({
+                to: "0x96081a4e7C3617a4d7dAc9AC84D97255d63773d2",
+                withRenParams: true,
+                method: "mint",
+                params: [
+                    {
+                        name: "_token",
+                        value: "0x4680fb30aa384c15ce6b409a3f6ba9064587c321",
+                        type: "address",
+                    },
+                    {
+                        name: "_to",
+                        value: "0x99b6be7f16a7bba42d7cdc9ca8e93028612dcbed",
+                        type: "address",
+                    },
+                ],
+            }),
         };
 
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
@@ -439,7 +454,7 @@ describe("Gateway", () => {
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
     }).timeout(100000000000);
 
-    it("USDT/toCatalog", async () => {
+    it.only("USDT/toCatalog", async () => {
         const network = RenNetwork.Testnet;
 
         const from = initializeChain(Goerli, network);
@@ -452,6 +467,9 @@ describe("Gateway", () => {
             bsc,
             polygon,
         );
+
+        console.log(await catalog.getRenAsset(from.assets.DAI));
+
         console.log(await from.signer!.getAddress());
 
         console.log(
@@ -564,7 +582,7 @@ describe("Gateway", () => {
         }
     }).timeout(100000000000);
 
-    it.only("REN/toSolana", async () => {
+    it("REN/toSolana", async () => {
         const network = RenNetwork.Testnet;
 
         const asset = Ethereum.assets.REN;

--- a/test/gateway.spec.ts
+++ b/test/gateway.spec.ts
@@ -425,13 +425,13 @@ describe("Gateway", () => {
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
     }).timeout(100000000000);
 
-    it("AVAX/fromSolana", async () => {
+    it.only("AVAX/toGoerli", async () => {
         const network = RenNetwork.Testnet;
         const renJS = new RenJS(network);
 
         const asset = Avalanche.assets.AVAX;
-        const from = initializeChain(Solana, network);
-        const to = initializeChain(Avalanche, network);
+        const from = initializeChain(Avalanche, network);
+        const to = initializeChain(Goerli, network);
         renJS.withChains(to, from);
 
         const amount = new BigNumber(1).shiftedBy(18);
@@ -454,7 +454,7 @@ describe("Gateway", () => {
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
     }).timeout(100000000000);
 
-    it.only("USDT/toCatalog", async () => {
+    it.skip("USDT/toCatalog", async () => {
         const network = RenNetwork.Testnet;
 
         const from = initializeChain(Goerli, network);

--- a/test/utils/defaultGatewayHandler.ts
+++ b/test/utils/defaultGatewayHandler.ts
@@ -118,7 +118,7 @@ export const defaultGatewayHandler = async (
                 gateway.gatewayAddress
             } (to receive at least ${receivedAmount.toFixed()})`,
         );
-        const SEND_FUNDS = true;
+        const SEND_FUNDS = false;
         if (SEND_FUNDS) {
             try {
                 await sendFunds(

--- a/test/utils/testUtils.ts
+++ b/test/utils/testUtils.ts
@@ -101,7 +101,7 @@ export const initializeChain = <T extends ChainCommon>(
                         INFURA_API_KEY: process.env.INFURA_KEY,
                     },
                 ),
-                testnet: "Kovan",
+                defaultTestnet: "kovan",
                 config,
             }) as ChainCommon as T;
 


### PR DESCRIPTION
Changelog:

1. Release 3.5.0 adds a required parameter `defaultTestnet` when initializing the `Ethereum` class to require developers to explicitly choose between `"goerli"` and `"kovan"`.
2. <img width="10px" src="https://moonbeam.network/wp-content/uploads/2020/03/cropped-Moonbeam-Favicon-550px-60x60.png" /> Moonbeam Mainnet addresses have been added
3. A `populateChainTransaction` method has also been added to each chain to facilitate converting from a `txid` to a `ChainTransaction` object.