### PR TITLE
Release 3.5.2: Remove Kovan, Update .assets to depend on network, add detectPreviousDeposits

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "3.5.1"
+    "version": "3.5.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "3.5.0"
+    "version": "3.5.1"
 }

--- a/packages/chains/chains-bitcoin/package.json
+++ b/packages/chains/chains-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-bitcoin",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "@noble/hashes": "1.1.2",
-        "@renproject/utils": "^3.5.1",
+        "@renproject/utils": "^3.5.2",
         "@types/bchaddrjs": "0.4.0",
         "@types/bs58": "4.0.1",
         "@types/bs58check": "2.1.0",

--- a/packages/chains/chains-bitcoin/package.json
+++ b/packages/chains/chains-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-bitcoin",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "@noble/hashes": "1.1.2",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.5.1",
         "@types/bchaddrjs": "0.4.0",
         "@types/bs58": "4.0.1",
         "@types/bs58check": "2.1.0",

--- a/packages/chains/chains-bitcoin/src/base.ts
+++ b/packages/chains/chains-bitcoin/src/base.ts
@@ -290,10 +290,7 @@ export abstract class BitcoinBaseChain
             // Ignore error and fallback to getUTXOs.
         }
 
-        while (true) {
-            if (listenerCancelled()) {
-                return;
-            }
+        while (!listenerCancelled()) {
             try {
                 const utxos = await this.api.fetchUTXOs(address);
                 utxos.map((tx) =>

--- a/packages/chains/chains-bitcoin/src/bitcoin.ts
+++ b/packages/chains/chains-bitcoin/src/bitcoin.ts
@@ -74,18 +74,29 @@ export class Bitcoin extends BitcoinBaseChain {
     public static configMap: BitcoinNetworkConfigMap = {
         [RenNetwork.Mainnet]: BitcoinMainnet,
         [RenNetwork.Testnet]: BitcoinTestnet,
-        [RenNetwork.Devnet]: BitcoinTestnet,
     };
     public configMap = Bitcoin.configMap;
 
     public static assets = {
-        BTC: "BTC",
+        [RenNetwork.Mainnet]: {
+            BTC: "BTC",
+        },
+        [RenNetwork.Testnet]: {
+            BTC: "BTC",
+        },
     };
-    public assets = Bitcoin.assets;
+
+    public assets:
+        | typeof Bitcoin.assets[RenNetwork.Mainnet]
+        | typeof Bitcoin.assets[RenNetwork.Testnet];
 
     public constructor({ network }: { network: BitcoinNetworkInput }) {
         super({
             network: resolveBitcoinNetworkConfig(Bitcoin.configMap, network),
         });
+        this.assets =
+            Bitcoin.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-bitcoin/src/bitcoincash.ts
+++ b/packages/chains/chains-bitcoin/src/bitcoincash.ts
@@ -69,14 +69,21 @@ export class BitcoinCash extends BitcoinBaseChain {
     public static configMap: BitcoinNetworkConfigMap = {
         [RenNetwork.Mainnet]: BitcoinCashMainnet,
         [RenNetwork.Testnet]: BitcoinCashTestnet,
-        [RenNetwork.Devnet]: BitcoinCashTestnet,
     };
     public configMap = BitcoinCash.configMap;
 
     public static assets = {
-        BCH: "BCH",
+        [RenNetwork.Mainnet]: {
+            BCH: "BCH",
+        },
+        [RenNetwork.Testnet]: {
+            BCH: "BCH",
+        },
     };
-    public assets = BitcoinCash.assets;
+
+    public assets:
+        | typeof BitcoinCash.assets[RenNetwork.Mainnet]
+        | typeof BitcoinCash.assets[RenNetwork.Testnet];
 
     public validateAddress = (address: string): boolean => {
         try {
@@ -106,5 +113,9 @@ export class BitcoinCash extends BitcoinBaseChain {
                 network,
             ),
         });
+        this.assets =
+            BitcoinCash.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-bitcoin/src/digibyte.ts
+++ b/packages/chains/chains-bitcoin/src/digibyte.ts
@@ -26,9 +26,6 @@ const DigiByteMainnet: BitcoinNetworkConfig = {
     explorer: StandardBitcoinExplorer("https://digiexplorer.info/"),
     p2shPrefix: new Uint8Array([0x3f]),
     providers: [
-        new Blockbook(
-            "https://multichain-web-proxy.herokuapp.com/digibyte-mainnet",
-        ),
         new Blockbook("https://digiexplorer.info/api"),
         new Blockbook("https://insight.digibyte.host/api"), // TODO: test again, currently broken
     ],

--- a/packages/chains/chains-bitcoin/src/digibyte.ts
+++ b/packages/chains/chains-bitcoin/src/digibyte.ts
@@ -60,14 +60,21 @@ export class DigiByte extends BitcoinBaseChain {
     public static configMap: BitcoinNetworkConfigMap = {
         [RenNetwork.Mainnet]: DigiByteMainnet,
         [RenNetwork.Testnet]: DigiByteTestnet,
-        [RenNetwork.Devnet]: DigiByteTestnet,
     };
     public configMap = DigiByte.configMap;
 
     public static assets = {
-        DGB: "DGB",
+        [RenNetwork.Mainnet]: {
+            DGB: "DGB",
+        },
+        [RenNetwork.Testnet]: {
+            DGB: "DGB",
+        },
     };
-    public assets = DigiByte.assets;
+
+    public assets:
+        | typeof DigiByte.assets[RenNetwork.Mainnet]
+        | typeof DigiByte.assets[RenNetwork.Testnet];
 
     public validateAddress = (address: string): boolean => {
         try {
@@ -93,5 +100,9 @@ export class DigiByte extends BitcoinBaseChain {
         super({
             network: resolveBitcoinNetworkConfig(DigiByte.configMap, network),
         });
+        this.assets =
+            DigiByte.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-bitcoin/src/dogecoin.ts
+++ b/packages/chains/chains-bitcoin/src/dogecoin.ts
@@ -54,14 +54,21 @@ export class Dogecoin extends BitcoinBaseChain {
     public static configMap: BitcoinNetworkConfigMap = {
         [RenNetwork.Mainnet]: DogecoinMainnet,
         [RenNetwork.Testnet]: DogecoinTestnet,
-        [RenNetwork.Devnet]: DogecoinTestnet,
     };
     public configMap = Dogecoin.configMap;
 
     public static assets = {
-        DOGE: "DOGE",
+        [RenNetwork.Mainnet]: {
+            DOGE: "DOGE",
+        },
+        [RenNetwork.Testnet]: {
+            DOGE: "DOGE",
+        },
     };
-    public assets = Dogecoin.assets;
+
+    public assets:
+        | typeof Dogecoin.assets[RenNetwork.Mainnet]
+        | typeof Dogecoin.assets[RenNetwork.Testnet];
 
     public validateAddress = (address: string): boolean => {
         try {
@@ -86,5 +93,9 @@ export class Dogecoin extends BitcoinBaseChain {
         super({
             network: resolveBitcoinNetworkConfig(Dogecoin.configMap, network),
         });
+        this.assets =
+            Dogecoin.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-bitcoin/src/zcash.ts
+++ b/packages/chains/chains-bitcoin/src/zcash.ts
@@ -63,18 +63,29 @@ export class Zcash extends BitcoinBaseChain {
     public static configMap: BitcoinNetworkConfigMap = {
         [RenNetwork.Mainnet]: ZcashMainnet,
         [RenNetwork.Testnet]: ZcashTestnet,
-        [RenNetwork.Devnet]: ZcashTestnet,
     };
     public configMap = Zcash.configMap;
 
     public static assets = {
-        ZEC: "ZEC",
+        [RenNetwork.Mainnet]: {
+            ZEC: "ZEC",
+        },
+        [RenNetwork.Testnet]: {
+            ZEC: "ZEC",
+        },
     };
-    public assets = Zcash.assets;
+
+    public assets:
+        | typeof Zcash.assets[RenNetwork.Mainnet]
+        | typeof Zcash.assets[RenNetwork.Testnet];
 
     public constructor({ network }: { network: BitcoinNetworkInput }) {
         super({
             network: resolveBitcoinNetworkConfig(Zcash.configMap, network),
         });
+        this.assets =
+            Zcash.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-bitcoin/test/digibyte.spec.ts
+++ b/packages/chains/chains-bitcoin/test/digibyte.spec.ts
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+import { RenNetwork } from "@renproject/utils";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+
+import { DigiByte } from "../src";
+import { APIWithPriority, BitcoinAPI } from "../src/APIs/API";
+
+describe("DigiByte", () => {
+    it("watch for deposits", async () => {
+        const digibyte = new DigiByte({ network: "mainnet" });
+        const providerConfig =
+            digibyte.configMap[RenNetwork.Mainnet].providers[0];
+        const provider: BitcoinAPI =
+            (providerConfig as APIWithPriority).api ||
+            (providerConfig as BitcoinAPI);
+
+        const txs = await provider.fetchUTXOs(
+            "DRNiw2k4iFuHGS2fF1wMahounXo6H9iGbh",
+        );
+
+        expect(txs[txs.length - 1]).to.deep.equal({
+            txid: "9f5c0a8146e7633911cbf5be44ebebb9b65bb360511f6795bea04c650ed600b8",
+            amount: "16205616929",
+            txindex: "2",
+            height: "3127600",
+        });
+    });
+});

--- a/packages/chains/chains-ethereum/package.json
+++ b/packages/chains/chains-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-ethereum",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,7 +45,7 @@
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/bytes": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@renproject/utils": "^3.5.1",
+        "@renproject/utils": "^3.5.2",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/chains/chains-ethereum/package.json
+++ b/packages/chains/chains-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-ethereum",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -45,7 +45,7 @@
         "@ethersproject/abi": "5.6.4",
         "@ethersproject/bytes": "5.6.1",
         "@ethersproject/providers": "5.6.8",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.5.1",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/chains/chains-ethereum/package.json
+++ b/packages/chains/chains-ethereum/package.json
@@ -42,14 +42,14 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/providers": "5.6.8",
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
         "@renproject/utils": "^3.5.1",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",
-        "ethers": "5.6.9"
+        "ethers": "5.7.2"
     },
     "nyc": {
         "extends": "@istanbuljs/nyc-config-typescript",

--- a/packages/chains/chains-ethereum/src/arbitrum.ts
+++ b/packages/chains/chains-ethereum/src/arbitrum.ts
@@ -68,11 +68,14 @@ export class Arbitrum extends EthereumBaseChain {
     public static chain = "Arbitrum" as const;
     public static configMap = configMap;
     public static assets = {
-        ArbETH: "ArbETH" as const,
+        [RenNetwork.Mainnet]: { ArbETH: "ArbETH" as const },
+        [RenNetwork.Testnet]: { ArbETH: "ArbETH" as const },
     };
 
     public configMap = configMap;
-    public assets = Arbitrum.assets;
+    public assets:
+        | typeof Arbitrum.assets[RenNetwork.Mainnet]
+        | typeof Arbitrum.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -82,5 +85,9 @@ export class Arbitrum extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            Arbitrum.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/avalanche.ts
+++ b/packages/chains/chains-ethereum/src/avalanche.ts
@@ -64,11 +64,14 @@ export class Avalanche extends EthereumBaseChain {
     public static chain = "Avalanche" as const;
     public static configMap = configMap;
     public static assets = {
-        AVAX: "AVAX" as const,
+        [RenNetwork.Mainnet]: { AVAX: "AVAX" as const },
+        [RenNetwork.Testnet]: { AVAX: "AVAX" as const },
     };
 
     public configMap = configMap;
-    public assets = Avalanche.assets;
+    public assets:
+        | typeof Avalanche.assets[RenNetwork.Mainnet]
+        | typeof Avalanche.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -78,5 +81,9 @@ export class Avalanche extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            Avalanche.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/base.ts
+++ b/packages/chains/chains-ethereum/src/base.ts
@@ -122,7 +122,10 @@ export class EthereumBaseChain
         this.network = resolveEVMNetworkConfig(this.configMap, network);
         this.chain = this.network.selector;
         this.explorer = StandardEVMExplorer(
-            this.network.config.blockExplorerUrls[0],
+            this.network.config.blockExplorerUrls &&
+                this.network.config.blockExplorerUrls.length
+                ? this.network.config.blockExplorerUrls[0]
+                : "",
         );
         this._logger = (config && config.logger) || defaultLogger;
         this._config = config;
@@ -427,7 +430,7 @@ export class EthereumBaseChain
                 ) {
                     // Ignore
                 } else {
-                    console.warn(error);
+                    this._logger.warn(error);
                 }
                 return false;
             }

--- a/packages/chains/chains-ethereum/src/base.ts
+++ b/packages/chains/chains-ethereum/src/base.ts
@@ -58,6 +58,7 @@ import {
     mapLockLogToInputChainTransaction,
     mapTransferLogToInputChainTransaction,
     resolveEVMNetworkConfig,
+    resolveRpcEndpoints,
     txHashFromBytes,
     txHashToBytes,
     txHashToChainTransaction,
@@ -114,7 +115,7 @@ export class EthereumBaseChain
         config,
     }: {
         network: EVMNetworkInput;
-        provider: EthProvider;
+        provider?: EthProvider;
         signer?: EthSigner;
         config?: EthereumClassConfig;
     }) {
@@ -128,7 +129,9 @@ export class EthereumBaseChain
 
         // Ignore not configured error.
         this.provider = undefined as never;
-        this.withProvider(provider);
+        this.withProvider(
+            provider || resolveRpcEndpoints(this.network.config.rpcUrls)[0],
+        );
         if (signer) {
             this.withSigner(signer);
         }

--- a/packages/chains/chains-ethereum/src/bsc.ts
+++ b/packages/chains/chains-ethereum/src/bsc.ts
@@ -96,10 +96,13 @@ export class BinanceSmartChain extends EthereumBaseChain {
     public static chain = "BinanceSmartChain" as const;
     public static configMap = configMap;
     public static assets = {
-        BNB: "BNB" as const,
+        [RenNetwork.Mainnet]: { BNB: "BNB" as const },
+        [RenNetwork.Testnet]: { BNB: "BNB" as const },
     };
 
-    public assets = BinanceSmartChain.assets;
+    public assets:
+        | typeof BinanceSmartChain.assets[RenNetwork.Mainnet]
+        | typeof BinanceSmartChain.assets[RenNetwork.Testnet];
     public configMap = configMap;
 
     public constructor({
@@ -110,5 +113,9 @@ export class BinanceSmartChain extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            BinanceSmartChain.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/catalog.ts
+++ b/packages/chains/chains-ethereum/src/catalog.ts
@@ -52,10 +52,15 @@ export class Catalog extends EthereumBaseChain {
     // Static members.
     public static chain = "Catalog" as const;
     public static configMap = configMap;
-    public static assets = {};
+    public static assets = {
+        [RenNetwork.Mainnet]: {},
+        [RenNetwork.Testnet]: {},
+    };
 
     public configMap = configMap;
-    public assets = Catalog.assets;
+    public assets:
+        | typeof Catalog.assets[RenNetwork.Mainnet]
+        | typeof Catalog.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -65,5 +70,9 @@ export class Catalog extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            Catalog.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/catalog.ts
+++ b/packages/chains/chains-ethereum/src/catalog.ts
@@ -15,7 +15,7 @@ const configMap: EthereumBaseChain["configMap"] = {
             chainName: "Catalog Mainnet",
             nativeCurrency: { name: "DCE EVM", symbol: "dceETH", decimals: 18 },
             rpcUrls: ["https://mainnet.catalog.fi/rpc"],
-            blockExplorerUrls: [""],
+            blockExplorerUrls: null,
         },
 
         addresses: {
@@ -35,7 +35,7 @@ const configMap: EthereumBaseChain["configMap"] = {
             chainName: "Catalog Testnet",
             nativeCurrency: { name: "DCE EVM", symbol: "dceETH", decimals: 18 },
             rpcUrls: ["https://rpc.catalog.fi/testnet"],
-            blockExplorerUrls: [""],
+            blockExplorerUrls: null,
         },
 
         addresses: {

--- a/packages/chains/chains-ethereum/src/contracts/index.ts
+++ b/packages/chains/chains-ethereum/src/contracts/index.ts
@@ -1,7 +1,6 @@
-import { Contract, Signer } from "ethers";
-
 import { Provider } from "@ethersproject/providers";
 import { utils } from "@renproject/utils";
+import { Contract, Signer } from "ethers";
 
 import { AbiItem } from "../utils/abi";
 import BasicBridgeJSON from "./ABIs/BasicBridge.json";

--- a/packages/chains/chains-ethereum/src/ethereum.ts
+++ b/packages/chains/chains-ethereum/src/ethereum.ts
@@ -29,41 +29,9 @@ const ethereumMainnetConfig: EVMNetworkConfig = {
     },
 };
 
-const kovanConfig: EVMNetworkConfig = {
-    selector: "Ethereum",
-    isTestnet: true,
-
-    nativeAsset: { name: "Kovan Ether", symbol: "ETH", decimals: 18 },
-    averageConfirmationTime: 15,
-
-    config: {
-        chainId: "0x2a",
-        chainName: "Kovan",
-        nativeCurrency: {
-            name: "Kovan Ether",
-            symbol: "KOV",
-            decimals: 18,
-        },
-        rpcUrls: [
-            "https://kovan.poa.network",
-            "http://kovan.poa.network:8545",
-            "https://kovan.infura.io/v3/${INFURA_API_KEY}",
-            "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
-            "wss://kovan.infura.io/ws/v3/${INFURA_API_KEY}",
-            "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
-            "ws://kovan.poa.network:8546",
-        ],
-        blockExplorerUrls: ["https://kovan.ethplorer.io"],
-    },
-
-    addresses: {
-        GatewayRegistry: "0x5076a1F237531fa4dC8ad99bb68024aB6e1Ff701",
-        BasicBridge: "0xcb6bD6B6c7D7415C0157e393Bb2B6Def7555d518",
-    },
-};
-
 const goerliConfig: EVMNetworkConfig = {
     selector: "Goerli",
+    isTestnet: true,
 
     nativeAsset: { name: "Görli Ether", symbol: "gETH", decimals: 18 },
     averageConfirmationTime: 15,
@@ -77,7 +45,7 @@ const goerliConfig: EVMNetworkConfig = {
             decimals: 18,
         },
         rpcUrls: [
-            "https://rpc.goerli.mudit.blog/",
+            "https://web3-trial.cloudflare-eth.com/v1/goerli",
             "https://goerli.infura.io/v3/${INFURA_API_KEY}",
             "https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_API_KEY}",
             "wss://goerli.infura.io/v3/${INFURA_API_KEY}",
@@ -94,7 +62,7 @@ const goerliConfig: EVMNetworkConfig = {
 
 export const defaultConfigMap: EthereumBaseChain["configMap"] = {
     [RenNetwork.Mainnet]: ethereumMainnetConfig,
-    [RenNetwork.Testnet]: kovanConfig,
+    [RenNetwork.Testnet]: goerliConfig,
 };
 
 export const goerliConfigMap: EthereumBaseChain["configMap"] = {
@@ -105,43 +73,7 @@ export const goerliConfigMap: EthereumBaseChain["configMap"] = {
 export enum EthereumTestnet {
     Goerli = "goerli",
     Görli = "goerli",
-    Kovan = "kovan",
 }
-
-const defaultAssets = {
-    ETH: "ETH" as const,
-    DAI: "DAI" as const,
-    REN: "REN" as const,
-    USDC: "USDC" as const,
-    USDT: "USDT" as const,
-    EURT: "EURT" as const,
-    BUSD: "BUSD" as const,
-    MIM: "MIM" as const,
-    CRV: "CRV" as const,
-    LINK: "LINK" as const,
-    UNI: "UNI" as const,
-    SUSHI: "SUSHI" as const,
-    FTT: "FTT" as const,
-    ROOK: "ROOK" as const,
-    BADGER: "BADGER" as const,
-    KNC: "KNC" as const,
-};
-
-const goerliAssets = {
-    ETH: "gETH" as const,
-    DAI: "DAI_Goerli" as const,
-    REN: "REN_Goerli" as const,
-    USDC: "USDC_Goerli" as const,
-    USDT: "USDT_Goerli" as const,
-
-    // Goerli only
-    gETH: "gETH" as const,
-    REN_Goerli: "REN_Goerli" as const,
-    DAI_Goerli: "DAI_Goerli" as const,
-    USDC_Goerli: "USDC_Goerli" as const,
-    USDT_Goerli: "USDT_Goerli" as const,
-    ETH_Goerli: "gETH" as const,
-};
 
 /**
  * The Ethereum RenJS implementation.
@@ -151,19 +83,52 @@ export class Ethereum extends EthereumBaseChain {
     public static chain = "Ethereum" as const;
     public static configMap = defaultConfigMap;
     public static assets = {
-        ...goerliAssets,
-        ...defaultAssets,
+        [RenNetwork.Mainnet]: {
+            ETH: "ETH" as const,
+            DAI: "DAI" as const,
+            REN: "REN" as const,
+            USDC: "USDC" as const,
+            USDT: "USDT" as const,
+            EURT: "EURT" as const,
+            BUSD: "BUSD" as const,
+            MIM: "MIM" as const,
+            CRV: "CRV" as const,
+            LINK: "LINK" as const,
+            UNI: "UNI" as const,
+            SUSHI: "SUSHI" as const,
+            FTT: "FTT" as const,
+            ROOK: "ROOK" as const,
+            BADGER: "BADGER" as const,
+            KNC: "KNC" as const,
+        },
+        [RenNetwork.Testnet]: {
+            ETH: "gETH" as const,
+            DAI: "DAI_Goerli" as const,
+            REN: "REN_Goerli" as const,
+            USDC: "USDC_Goerli" as const,
+            USDT: "USDT_Goerli" as const,
+
+            // Goerli only
+            gETH: "gETH" as const,
+            REN_Goerli: "REN_Goerli" as const,
+            DAI_Goerli: "DAI_Goerli" as const,
+            USDC_Goerli: "USDC_Goerli" as const,
+            USDT_Goerli: "USDT_Goerli" as const,
+            ETH_Goerli: "gETH" as const,
+        },
     };
 
     public configMap = Ethereum.configMap;
-    public assets = Ethereum.assets;
+    public assets:
+        | typeof Ethereum.assets[RenNetwork.Mainnet]
+        | typeof Ethereum.assets[RenNetwork.Testnet];
 
     /**
      * Create a new Ethereum instance.
      *
      * @param params Ethereum constructor parameters
      * @param params.network A RenVM network string or an EVM config object.
-     * @param params.testnet Optionally specify a default Ethereum testnet.
+     * @param params.defaultTestnet Optionally specify a default Ethereum testnet.
      * @param params.provider A Web3 or Ethers.js provider.
      * @param params.signer A Web3 or Ethers.js signer.
      * @param params.config Pass optional configurations, e.g. a logger
@@ -175,24 +140,18 @@ export class Ethereum extends EthereumBaseChain {
     }: ConstructorParameters<typeof EthereumBaseChain>[0] & {
         defaultTestnet: EthereumTestnet | `${EthereumTestnet}`;
     }) {
-        super({
-            ...params,
-            network: resolveEVMNetworkConfig(
-                defaultTestnet === EthereumTestnet.Görli
-                    ? goerliConfigMap
-                    : defaultConfigMap,
-                network,
-            ),
-        });
-        this.configMap =
+        const configMap =
             defaultTestnet === EthereumTestnet.Görli
                 ? goerliConfigMap
                 : defaultConfigMap;
-        this.assets = (
-            defaultTestnet === EthereumTestnet.Görli &&
-            network === RenNetwork.Testnet
-                ? goerliAssets
-                : defaultAssets
-        ) as typeof this.assets;
+        super({
+            ...params,
+            network: resolveEVMNetworkConfig(configMap, network),
+        });
+        this.configMap = configMap;
+        this.assets =
+            Ethereum.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/fantom.ts
+++ b/packages/chains/chains-ethereum/src/fantom.ts
@@ -59,11 +59,14 @@ export class Fantom extends EthereumBaseChain {
     public static chain = "Fantom" as const;
     public static configMap = configMap;
     public static assets = {
-        FTM: "FTM" as const,
+        [RenNetwork.Mainnet]: { FTM: "FTM" as const },
+        [RenNetwork.Testnet]: { FTM: "FTM" as const },
     };
 
     public configMap = Fantom.configMap;
-    public assets = Fantom.assets;
+    public assets:
+        | typeof Fantom.assets[RenNetwork.Mainnet]
+        | typeof Fantom.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -73,5 +76,9 @@ export class Fantom extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            Fantom.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/goerli.ts
+++ b/packages/chains/chains-ethereum/src/goerli.ts
@@ -1,3 +1,5 @@
+import { RenNetwork } from "@renproject/utils";
+
 import { EthereumBaseChain } from "./base";
 import { EthereumTestnet, goerliConfigMap } from "./ethereum";
 import { resolveEVMNetworkConfig } from "./utils/generic";
@@ -7,23 +9,25 @@ export class Goerli extends EthereumBaseChain {
     public static chain = "Goerli" as const;
     public static configMap = goerliConfigMap;
     public static assets = {
-        gETH: "gETH" as const,
-        REN: "REN_Goerli" as const,
-        DAI: "DAI_Goerli" as const,
-        USDC: "USDC_Goerli" as const,
-        USDT: "USDT_Goerli" as const,
+        [RenNetwork.Testnet]: {
+            gETH: "gETH" as const,
+            REN: "REN_Goerli" as const,
+            DAI: "DAI_Goerli" as const,
+            USDC: "USDC_Goerli" as const,
+            USDT: "USDT_Goerli" as const,
 
-        // Aliases
-        ETH: "gETH" as const,
-        ETH_Goerli: "gETH" as const,
-        REN_Goerli: "REN_Goerli" as const,
-        DAI_Goerli: "DAI_Goerli" as const,
-        USDC_Goerli: "USDC_Goerli" as const,
-        USDT_Goerli: "USDT_Goerli" as const,
+            // Aliases
+            ETH: "gETH" as const,
+            ETH_Goerli: "gETH" as const,
+            REN_Goerli: "REN_Goerli" as const,
+            DAI_Goerli: "DAI_Goerli" as const,
+            USDC_Goerli: "USDC_Goerli" as const,
+            USDT_Goerli: "USDT_Goerli" as const,
+        },
     };
 
     public configMap = goerliConfigMap;
-    public assets = Goerli.assets;
+    public assets: typeof Goerli.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -35,5 +39,6 @@ export class Goerli extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(goerliConfigMap, network),
         });
+        this.assets = Goerli.assets[RenNetwork.Testnet];
     }
 }

--- a/packages/chains/chains-ethereum/src/kava.ts
+++ b/packages/chains/chains-ethereum/src/kava.ts
@@ -60,11 +60,14 @@ export class Kava extends EthereumBaseChain {
     public static chain = "Kava" as const;
     public static configMap = configMap;
     public static assets = {
-        KAVA: "KAVA" as const,
+        [RenNetwork.Mainnet]: { KAVA: "KAVA" as const },
+        [RenNetwork.Testnet]: { KAVA: "KAVA" as const },
     };
 
     public configMap = configMap;
-    public assets = Kava.assets;
+    public assets:
+        | typeof Kava.assets[RenNetwork.Mainnet]
+        | typeof Kava.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -74,5 +77,9 @@ export class Kava extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            Kava.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/moonbeam.ts
+++ b/packages/chains/chains-ethereum/src/moonbeam.ts
@@ -58,11 +58,14 @@ export class Moonbeam extends EthereumBaseChain {
     public static chain = "Moonbeam" as const;
     public static configMap = configMap;
     public static assets = {
-        GLMR: "GLMR" as const,
+        [RenNetwork.Mainnet]: { GLMR: "GLMR" as const },
+        [RenNetwork.Testnet]: { GLMR: "GLMR" as const },
     };
 
     public configMap = configMap;
-    public assets = Moonbeam.assets;
+    public assets:
+        | typeof Moonbeam.assets[RenNetwork.Mainnet]
+        | typeof Moonbeam.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -72,5 +75,9 @@ export class Moonbeam extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            Moonbeam.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/optimism.ts
+++ b/packages/chains/chains-ethereum/src/optimism.ts
@@ -60,11 +60,14 @@ export class Optimism extends EthereumBaseChain {
     public static chain = "Optimism" as const;
     public static configMap = configMap;
     public static assets = {
-        oETH: "oETH" as const,
+        [RenNetwork.Mainnet]: { oETH: "oETH" as const },
+        [RenNetwork.Testnet]: { oETH: "oETH" as const },
     };
 
     public configMap = configMap;
-    public assets = Optimism.assets;
+    public assets:
+        | typeof Optimism.assets[RenNetwork.Mainnet]
+        | typeof Optimism.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -74,5 +77,9 @@ export class Optimism extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            Optimism.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/polygon.ts
+++ b/packages/chains/chains-ethereum/src/polygon.ts
@@ -72,11 +72,14 @@ export class Polygon extends EthereumBaseChain {
     public static chain = "Polygon" as const;
     public static configMap = configMap;
     public static assets = {
-        MATIC: "MATIC" as const,
+        [RenNetwork.Mainnet]: { MATIC: "MATIC" as const },
+        [RenNetwork.Testnet]: { MATIC: "MATIC" as const },
     };
 
     public configMap = configMap;
-    public assets = Polygon.assets;
+    public assets:
+        | typeof Polygon.assets[RenNetwork.Mainnet]
+        | typeof Polygon.assets[RenNetwork.Testnet];
 
     public constructor({
         network,
@@ -86,5 +89,9 @@ export class Polygon extends EthereumBaseChain {
             ...params,
             network: resolveEVMNetworkConfig(configMap, network),
         });
+        this.assets =
+            Polygon.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 }

--- a/packages/chains/chains-ethereum/src/utils/payloads/evmParams.ts
+++ b/packages/chains/chains-ethereum/src/utils/payloads/evmParams.ts
@@ -100,10 +100,13 @@ export interface EVMPayloadInterface<Name extends string = string, T = any> {
     };
 
     payloadConfig?: {
+        detectPreviousDeposits?: boolean;
+
         /**
          * Whether the `to` field passed to the RenVM transaction should remain
          * preserved, for resuming a transaction that was created with a
-         * non-standard address format (no 0x prefix, or no checksum)
+         * non-standard address format (no 0x prefix, or no checksum). This is
+         * used by the RenVM Explorer.
          */
         preserveAddressFormat?: boolean;
     };

--- a/packages/chains/chains-ethereum/src/utils/types.ts
+++ b/packages/chains/chains-ethereum/src/utils/types.ts
@@ -32,7 +32,7 @@ export interface EIP3085Config {
     chainId: string;
 
     /** One or more URLs pointing to block explorer web sites for the chain. */
-    blockExplorerUrls: string[];
+    blockExplorerUrls: string[] | null;
 
     /** A human-readable name for the chain. */
     chainName: string;

--- a/packages/chains/chains-ethereum/test/assets.spec.ts
+++ b/packages/chains/chains-ethereum/test/assets.spec.ts
@@ -1,16 +1,18 @@
 /* eslint-disable no-console */
 
+import { join } from "path";
+
 import { RenNetwork } from "@renproject/utils";
 import chai, { expect } from "chai";
 import { config as loadDotEnv } from "dotenv";
 
 import { Goerli, resolveRpcEndpoints } from "../src";
 
-loadDotEnv({ path: "../../../.env" });
+loadDotEnv({ path: join(__dirname, "../../../../.env") });
 
 chai.should();
 
-describe.only("asset", () => {
+describe("asset", () => {
     it("Fetch lock and mint assets", async () => {
         const chain = new Goerli({
             provider: resolveRpcEndpoints(
@@ -26,6 +28,6 @@ describe.only("asset", () => {
         expect(await chain.getLockAsset("DAI_Goerli")).to.not.be.empty;
         expect(await chain.getLockAsset("USDC_Goerli")).to.not.be.empty;
         expect(await chain.getLockAsset("REN_Goerli")).to.not.be.empty;
-        expect(await chain.getLockAsset("gUSD")).to.not.be.empty;
+        expect(await chain.getLockAsset("USDT_Goerli")).to.not.be.empty;
     });
 });

--- a/packages/chains/chains-ethereum/test/assets.spec.ts
+++ b/packages/chains/chains-ethereum/test/assets.spec.ts
@@ -1,0 +1,31 @@
+/* eslint-disable no-console */
+
+import { RenNetwork } from "@renproject/utils";
+import chai, { expect } from "chai";
+import { config as loadDotEnv } from "dotenv";
+
+import { Goerli, resolveRpcEndpoints } from "../src";
+
+loadDotEnv({ path: "../../../.env" });
+
+chai.should();
+
+describe.only("asset", () => {
+    it("Fetch lock and mint assets", async () => {
+        const chain = new Goerli({
+            provider: resolveRpcEndpoints(
+                Goerli.configMap["testnet"].config.rpcUrls,
+                {
+                    INFURA_API_KEY: process.env.INFURA_KEY,
+                },
+            )[0],
+            network: RenNetwork.Testnet,
+            defaultTestnet: "goerli",
+        });
+
+        expect(await chain.getLockAsset("DAI_Goerli")).to.not.be.empty;
+        expect(await chain.getLockAsset("USDC_Goerli")).to.not.be.empty;
+        expect(await chain.getLockAsset("REN_Goerli")).to.not.be.empty;
+        expect(await chain.getLockAsset("gUSD")).to.not.be.empty;
+    });
+});

--- a/packages/chains/chains-ethereum/test/initialization.spec.ts
+++ b/packages/chains/chains-ethereum/test/initialization.spec.ts
@@ -6,7 +6,7 @@ import { config as loadDotEnv } from "dotenv";
 
 import { Ethereum } from "../src/ethereum";
 
-loadDotEnv();
+loadDotEnv({ path: "../../../.env" });
 
 chai.should();
 

--- a/packages/chains/chains-ethereum/test/initialization.spec.ts
+++ b/packages/chains/chains-ethereum/test/initialization.spec.ts
@@ -1,12 +1,14 @@
 /* eslint-disable no-console */
 
+import { join } from "path";
+
 import { RenNetwork } from "@renproject/utils";
 import chai, { expect } from "chai";
 import { config as loadDotEnv } from "dotenv";
 
 import { Ethereum } from "../src/ethereum";
 
-loadDotEnv({ path: "../../../.env" });
+loadDotEnv({ path: join(__dirname, "../../../../.env") });
 
 chai.should();
 
@@ -20,15 +22,6 @@ describe("Initialization", () => {
 
         expect(mainnet.configMap.mainnet.selector).to.equal("Ethereum");
         expect(mainnet.assets.ETH).to.equal("ETH");
-
-        const kovan = new Ethereum({
-            network: RenNetwork.Testnet,
-            provider: "",
-            defaultTestnet: "kovan",
-        });
-
-        expect(kovan.configMap.testnet.selector).to.equal("Ethereum");
-        expect(kovan.assets.ETH).to.equal("ETH");
 
         const goerli = new Ethereum({
             network: RenNetwork.Testnet,

--- a/packages/chains/chains-ethereum/test/logs.spec.ts
+++ b/packages/chains/chains-ethereum/test/logs.spec.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 
+import { join } from "path";
+
 import { RenNetwork } from "@renproject/utils";
 import chai from "chai";
 import { config as loadDotEnv } from "dotenv";
@@ -15,7 +17,7 @@ import {
     mapLockLogToInputChainTransaction,
 } from "../src/utils/generic";
 
-loadDotEnv({ path: "../../../.env" });
+loadDotEnv({ path: join(__dirname, "../../../../.env") });
 
 chai.should();
 

--- a/packages/chains/chains-ethereum/test/logs.spec.ts
+++ b/packages/chains/chains-ethereum/test/logs.spec.ts
@@ -15,7 +15,7 @@ import {
     mapLockLogToInputChainTransaction,
 } from "../src/utils/generic";
 
-loadDotEnv();
+loadDotEnv({ path: "../../../.env" });
 
 chai.should();
 
@@ -37,7 +37,7 @@ describe("Logs", () => {
             receipt.logs,
             logLockABI,
         ).map((e) =>
-            mapLockLogToInputChainTransaction("Ethereun", "BTC", e, ""),
+            mapLockLogToInputChainTransaction("Ethereun", "BTC", e.event, ""),
         );
         console.debug(lockDetails);
     });

--- a/packages/chains/chains-ethereum/test/utils.spec.ts
+++ b/packages/chains/chains-ethereum/test/utils.spec.ts
@@ -16,6 +16,7 @@ describe("Ethereum utils", () => {
     it("addressIsValid", () => {
         const ethereum = new Ethereum({
             network: "testnet",
+            defaultTestnet: "kovan",
             provider: new providers.JsonRpcProvider(
                 Ethereum.configMap["testnet"].config.rpcUrls[0],
             ),
@@ -56,6 +57,7 @@ describe("Utils", () => {
     it("validateTransaction", () => {
         const ethereum = new Ethereum({
             network: "testnet",
+            defaultTestnet: "kovan",
             provider: { _isProvider: true } as unknown as EthProvider,
         });
 

--- a/packages/chains/chains-ethereum/test/utils.spec.ts
+++ b/packages/chains/chains-ethereum/test/utils.spec.ts
@@ -16,7 +16,7 @@ describe("Ethereum utils", () => {
     it("addressIsValid", () => {
         const ethereum = new Ethereum({
             network: "testnet",
-            defaultTestnet: "kovan",
+            defaultTestnet: "goerli",
             provider: new providers.JsonRpcProvider(
                 Ethereum.configMap["testnet"].config.rpcUrls[0],
             ),
@@ -57,7 +57,7 @@ describe("Utils", () => {
     it("validateTransaction", () => {
         const ethereum = new Ethereum({
             network: "testnet",
-            defaultTestnet: "kovan",
+            defaultTestnet: "goerli",
             provider: { _isProvider: true } as unknown as EthProvider,
         });
 

--- a/packages/chains/chains-filecoin/package.json
+++ b/packages/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -44,7 +44,7 @@
     "dependencies": {
         "@glif/filecoin-address": "1.1.0",
         "@glif/filecoin-rpc-client": "1.1.0",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.5.1",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "blakejs": "1.2.1",

--- a/packages/chains/chains-filecoin/package.json
+++ b/packages/chains/chains-filecoin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-filecoin",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -44,7 +44,7 @@
     "dependencies": {
         "@glif/filecoin-address": "1.1.0",
         "@glif/filecoin-rpc-client": "1.1.0",
-        "@renproject/utils": "^3.5.1",
+        "@renproject/utils": "^3.5.2",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "blakejs": "1.2.1",

--- a/packages/chains/chains-filecoin/src/filecoin.ts
+++ b/packages/chains/chains-filecoin/src/filecoin.ts
@@ -74,7 +74,7 @@ const FilecoinMainnet: FilecoinNetworkConfig = {
     explorer: "https://filfox.info/en",
 
     rpc: {
-        apiAddress: `https://multichain-web-proxy.herokuapp.com/mainnet`,
+        apiAddress: `https://api.node.glif.io`,
     },
 
     filfoxAPI: "https://filfox.info/api/v1/",
@@ -95,7 +95,7 @@ const FilecoinTestnet: FilecoinNetworkConfig = {
     explorer: "https://calibration.filscan.io",
 
     rpc: {
-        apiAddress: `https://multichain-web-proxy.herokuapp.com/testnet`,
+        apiAddress: `https://api.calibration.node.glif.io`,
     },
 };
 

--- a/packages/chains/chains-filecoin/src/filecoin.ts
+++ b/packages/chains/chains-filecoin/src/filecoin.ts
@@ -40,6 +40,7 @@ export interface FilecoinNetworkConfig {
     averageConfirmationTime: number;
     addressPrefix: string;
     explorer: string;
+    isTestnet?: boolean;
 
     // RPC details
     rpc: {
@@ -82,6 +83,7 @@ const FilecoinMainnet: FilecoinNetworkConfig = {
 
 const FilecoinTestnet: FilecoinNetworkConfig = {
     selector: "Filecoin",
+    isTestnet: true,
 
     nativeAsset: {
         name: "Filecoin",
@@ -126,14 +128,16 @@ export class Filecoin
     public static chain = "Filecoin" as const;
     public chain: string;
     public static assets = {
-        FIL: "FIL",
+        [RenNetwork.Mainnet]: { FIL: "FIL" as const },
+        [RenNetwork.Testnet]: { FIL: "FIL" as const },
     };
-    public assets = Filecoin.assets;
+    public assets:
+        | typeof Filecoin.assets[RenNetwork.Mainnet]
+        | typeof Filecoin.assets[RenNetwork.Testnet];
 
     public static configMap = {
         [RenNetwork.Mainnet]: FilecoinMainnet,
         [RenNetwork.Testnet]: FilecoinTestnet,
-        [RenNetwork.Devnet]: FilecoinTestnet,
     };
     public configMap = Filecoin.configMap;
 
@@ -164,6 +168,10 @@ export class Filecoin
 
         this.network = networkConfig;
         this.chain = this.network.selector;
+        this.assets =
+            Filecoin.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
         this.clientOptions = options || {};
 
         this.client = new FilecoinClient(this.network.rpc);

--- a/packages/chains/chains-filecoin/src/utils/deposit.ts
+++ b/packages/chains/chains-filecoin/src/utils/deposit.ts
@@ -1,7 +1,6 @@
 export enum FilNetwork {
     Mainnet = "mainnet",
     Testnet = "testnet",
-    Devnet = "devnet",
 }
 
 export interface FilTransaction {

--- a/packages/chains/chains-filecoin/test/explorers.spec.ts
+++ b/packages/chains/chains-filecoin/test/explorers.spec.ts
@@ -7,7 +7,7 @@ import { Filfox } from "../src/utils/filfox";
 
 chai.should();
 
-loadDotEnv();
+loadDotEnv({ path: "../../../.env" });
 
 describe.skip("Filecoin explorers", () => {
     it("mint to contract", async () => {

--- a/packages/chains/chains-filecoin/test/explorers.spec.ts
+++ b/packages/chains/chains-filecoin/test/explorers.spec.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 
+import { join } from "path";
+
 import chai from "chai";
 import { config as loadDotEnv } from "dotenv";
 
@@ -7,7 +9,7 @@ import { Filfox } from "../src/utils/filfox";
 
 chai.should();
 
-loadDotEnv({ path: "../../../.env" });
+loadDotEnv({ path: join(__dirname, "../../../../.env") });
 
 describe.skip("Filecoin explorers", () => {
     it("mint to contract", async () => {

--- a/packages/chains/chains-filecoin/test/index.spec.ts
+++ b/packages/chains/chains-filecoin/test/index.spec.ts
@@ -10,7 +10,7 @@ import { fetchDeposits, getHeight } from "../src/utils/lotus";
 
 chai.should();
 
-loadDotEnv();
+loadDotEnv({ path: "../../../.env" });
 
 describe("Filecoin", () => {
     it("mint to contract", () => {

--- a/packages/chains/chains-filecoin/test/index.spec.ts
+++ b/packages/chains/chains-filecoin/test/index.spec.ts
@@ -98,7 +98,7 @@ describe("Filecoin", () => {
 describe.skip("Filecoin", () => {
     it("lotus", async () => {
         const client = new FilecoinClient({
-            apiAddress: `https://multichain-web-proxy.herokuapp.com/testnet`,
+            apiAddress: `https://api.calibration.node.glif.io`,
         });
 
         const height = await getHeight(client);

--- a/packages/chains/chains-filecoin/test/index.spec.ts
+++ b/packages/chains/chains-filecoin/test/index.spec.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 
+import { join } from "path";
+
 import FilecoinClient from "@glif/filecoin-rpc-client";
 import { utils } from "@renproject/utils";
 import chai, { expect } from "chai";
@@ -10,7 +12,7 @@ import { fetchDeposits, getHeight } from "../src/utils/lotus";
 
 chai.should();
 
-loadDotEnv({ path: "../../../.env" });
+loadDotEnv({ path: join(__dirname, "../../../../.env") });
 
 describe("Filecoin", () => {
     it("mint to contract", () => {

--- a/packages/chains/chains-solana/package.json
+++ b/packages/chains/chains-solana/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-solana",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.1",
+        "@renproject/utils": "^3.5.2",
         "@scure/bip39": "1.1.0",
         "@solana/spl-token": "0.2.0",
         "@solana/web3.js": "1.50.1",

--- a/packages/chains/chains-solana/package.json
+++ b/packages/chains/chains-solana/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-solana",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.5.1",
         "@scure/bip39": "1.1.0",
         "@solana/spl-token": "0.2.0",
         "@solana/web3.js": "1.50.1",

--- a/packages/chains/chains-solana/src/index.ts
+++ b/packages/chains/chains-solana/src/index.ts
@@ -1,10 +1,5 @@
 export { Solana } from "./solana";
 export * from "./types/types";
 
-export {
-    SolNetworkConfig,
-    renMainnet,
-    renTestnet,
-    renDevnet,
-} from "./networks";
+export { SolNetworkConfig, renMainnet, renTestnet } from "./networks";
 export { signerFromPrivateKey } from "./utils";

--- a/packages/chains/chains-solana/src/networks.ts
+++ b/packages/chains/chains-solana/src/networks.ts
@@ -35,8 +35,6 @@ export const resolveNetwork = (
                 return renMainnet;
             case RenNetwork.Testnet:
                 return renTestnet;
-            case RenNetwork.Devnet:
-                return renDevnet;
         }
         throw new Error(`Unrecognized solana network ${networkInput}.`);
     }
@@ -90,26 +88,4 @@ export const renTestnet: SolNetworkConfig = {
         GatewayRegistry: "REGrPFKQhRneFFdUV3e9UDdzqUJyS6SKj88GdXFCRd2",
     },
     genesisHash: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
-};
-
-export const renDevnet: SolNetworkConfig = {
-    name: RenNetwork.Devnet,
-    symbol: "SOL",
-    chain: "testnet",
-    isTestnet: true,
-    chainLabel: "Testnet",
-
-    nativeAsset: {
-        name: "Solana",
-        symbol: "SOL",
-        decimals: 18,
-    },
-    averageConfirmationTime: 0.5,
-
-    endpoint: "https://api.testnet.solana.com",
-    chainExplorer: "https://explorer.solana.com",
-    addresses: {
-        GatewayRegistry: "REGrPFKQhRneFFdUV3e9UDdzqUJyS6SKj88GdXFCRd2",
-    },
-    genesisHash: "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY",
 };

--- a/packages/chains/chains-solana/src/solana.ts
+++ b/packages/chains/chains-solana/src/solana.ts
@@ -64,7 +64,8 @@ export class Solana
     public static chain = "Solana" as const;
     public chain = Solana.chain;
     public static assets = {
-        SOL: "SOL",
+        [RenNetwork.Mainnet]: { SOL: "SOL" as const },
+        [RenNetwork.Testnet]: { SOL: "SOL" as const },
     };
     public assets: { [asset: string]: string } = {};
 
@@ -95,6 +96,10 @@ export class Solana
             typeof provider === "string" || !provider
                 ? new Connection(provider || this.network.endpoint)
                 : provider;
+        this.assets =
+            Solana.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
         this._logger = config && config.logger ? config.logger : defaultLogger;
     }
 

--- a/packages/chains/chains-solana/test/solana.spec.ts
+++ b/packages/chains/chains-solana/test/solana.spec.ts
@@ -11,7 +11,7 @@ import { expect } from "chai";
 
 import { Solana } from "../src/index";
 import { RenVMMessageLayout } from "../src/layouts";
-import { renDevnet, renTestnet } from "../src/networks";
+import { renTestnet } from "../src/networks";
 import { signerFromPrivateKey } from "../src/utils";
 
 const testPK = Buffer.from(
@@ -41,8 +41,8 @@ describe("Solana", () => {
     describe("Chain initialization", () => {
         it("should initialize with a nodejs provider", () => {
             const solana = new Solana({
-                network: renDevnet,
-                provider: new Connection(renDevnet.endpoint),
+                network: renTestnet,
+                provider: new Connection(renTestnet.endpoint),
                 signer: signerFromPrivateKey(testPK),
             });
             expect(solana.network.isTestnet).to.equal(true);
@@ -50,8 +50,8 @@ describe("Solana", () => {
 
         it("should be able to check if an asset is supported", async () => {
             const solana = new Solana({
-                network: renDevnet,
-                provider: new Connection(renDevnet.endpoint),
+                network: renTestnet,
+                provider: new Connection(renTestnet.endpoint),
                 signer: signerFromPrivateKey(testPK),
             });
             // await solana.initialize("devnet");
@@ -61,13 +61,13 @@ describe("Solana", () => {
 
         it("should be able to return the program address for an asset", async () => {
             const solana = new Solana({
-                network: renDevnet,
-                provider: new Connection(renDevnet.endpoint),
+                network: renTestnet,
+                provider: new Connection(renTestnet.endpoint),
                 signer: signerFromPrivateKey(testPK),
             });
             const res = await solana.getMintGateway("BTC");
             expect(res).to.equal(
-                "BTC5yiRuonJKcQvD9j9QwYKPx4MCGbvkWfvHFyBJG6RY",
+                "FsEACSS3nKamRKdJBaBDpZtDXWrHR2nByahr4ReoYMBH",
             );
         });
 

--- a/packages/chains/chains-terra/package.json
+++ b/packages/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.1",
+        "@renproject/utils": "^3.5.2",
         "@terra-money/terra.js": "3.1.5",
         "@types/elliptic": "6.4.14",
         "bech32": "2.0.0",

--- a/packages/chains/chains-terra/package.json
+++ b/packages/chains/chains-terra/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains-terra",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,7 +42,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.5.1",
         "@terra-money/terra.js": "3.1.5",
         "@types/elliptic": "6.4.14",
         "bech32": "2.0.0",

--- a/packages/chains/chains-terra/src/api/types.ts
+++ b/packages/chains/chains-terra/src/api/types.ts
@@ -4,6 +4,7 @@ export interface TerraNetworkConfig {
     selector: string;
     chainId: string;
     addressPrefix: string;
+    isTestnet?: boolean;
 
     nativeAsset: {
         name: string;

--- a/packages/chains/chains-terra/src/terra.ts
+++ b/packages/chains/chains-terra/src/terra.ts
@@ -40,6 +40,7 @@ export const TerraTestnet: TerraNetworkConfig = {
     selector: "Terra",
     chainId: "bombay-12",
     addressPrefix: "terra",
+    isTestnet: true,
 
     nativeAsset: {
         name: "Luna",
@@ -55,7 +56,6 @@ export const TerraTestnet: TerraNetworkConfig = {
 export const TerraConfigMap = {
     [RenNetwork.Mainnet]: TerraMainnet,
     [RenNetwork.Testnet]: TerraTestnet,
-    [RenNetwork.Devnet]: TerraTestnet,
 };
 
 export type TerraInputPayload =
@@ -98,9 +98,12 @@ export class Terra
 
     // The assets native to Terra.
     public static assets = {
-        LUNA: "LUNA",
+        [RenNetwork.Mainnet]: { LUNA: "LUNA" as const },
+        [RenNetwork.Testnet]: { LUNA: "LUNA" as const },
     };
-    public assets = Terra.assets;
+    public assets:
+        | typeof Terra.assets[RenNetwork.Mainnet]
+        | typeof Terra.assets[RenNetwork.Testnet];
 
     public validateAddress = (address: string): boolean => {
         assertType<string>("string", { address: address });
@@ -189,6 +192,10 @@ export class Terra
         this.network = networkConfig;
         this.chain = this.network.selector;
         this.api = new TerraDev(this.network);
+        this.assets =
+            Terra.assets[
+                this.network.isTestnet ? RenNetwork.Testnet : RenNetwork.Mainnet
+            ];
     }
 
     public isLockAsset = (asset: string): boolean => {
@@ -213,7 +220,7 @@ export class Terra
      */
     public assetDecimals = (asset: string): number => {
         switch (asset) {
-            case Terra.assets.LUNA:
+            case this.assets.LUNA:
                 return 6;
         }
         throw new Error(`Unsupported asset ${String(asset)}.`);

--- a/packages/chains/chains/package.json
+++ b/packages/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,12 +42,12 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^3.5.0",
-        "@renproject/chains-ethereum": "^3.5.0",
-        "@renproject/chains-filecoin": "^3.5.0",
-        "@renproject/chains-solana": "^3.5.0",
-        "@renproject/chains-terra": "^3.5.0",
-        "@renproject/utils": "^3.5.0"
+        "@renproject/chains-bitcoin": "^3.5.1",
+        "@renproject/chains-ethereum": "^3.5.1",
+        "@renproject/chains-filecoin": "^3.5.1",
+        "@renproject/chains-solana": "^3.5.1",
+        "@renproject/chains-terra": "^3.5.1",
+        "@renproject/utils": "^3.5.1"
     },
     "nyc": {
         "extends": "@istanbuljs/nyc-config-typescript",

--- a/packages/chains/chains/package.json
+++ b/packages/chains/chains/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/chains",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,12 +42,12 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^3.5.1",
-        "@renproject/chains-ethereum": "^3.5.1",
-        "@renproject/chains-filecoin": "^3.5.1",
-        "@renproject/chains-solana": "^3.5.1",
-        "@renproject/chains-terra": "^3.5.1",
-        "@renproject/utils": "^3.5.1"
+        "@renproject/chains-bitcoin": "^3.5.2",
+        "@renproject/chains-ethereum": "^3.5.2",
+        "@renproject/chains-filecoin": "^3.5.2",
+        "@renproject/chains-solana": "^3.5.2",
+        "@renproject/chains-terra": "^3.5.2",
+        "@renproject/utils": "^3.5.2"
     },
     "nyc": {
         "extends": "@istanbuljs/nyc-config-typescript",

--- a/packages/chains/chains/src/index.ts
+++ b/packages/chains/chains/src/index.ts
@@ -27,6 +27,7 @@ import {
 import { Filecoin } from "@renproject/chains-filecoin";
 import { Solana } from "@renproject/chains-solana";
 import { Terra } from "@renproject/chains-terra";
+import { RenNetwork } from "@renproject/utils";
 
 export const chains = {
     Arbitrum,
@@ -87,7 +88,13 @@ export enum Asset {
 }
 
 export const assets = Object.values(chains).reduce<string[]>(
-    (acc, chain) => acc.concat(Object.values(chain.assets)),
+    (acc, chain) =>
+        acc.concat(
+            Object.values(
+                chain.assets[RenNetwork.Mainnet] ||
+                    chain.assets[RenNetwork.Testnet],
+            ),
+        ),
     [],
 );
 

--- a/packages/mock-provider/package.json
+++ b/packages/mock-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/mock-provider",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^3.5.0",
-        "@renproject/provider": "^3.5.0",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/chains-bitcoin": "^3.5.1",
+        "@renproject/provider": "^3.5.1",
+        "@renproject/utils": "^3.5.1",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/mock-provider/package.json
+++ b/packages/mock-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/mock-provider",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"
@@ -42,9 +42,9 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/chains-bitcoin": "^3.5.1",
-        "@renproject/provider": "^3.5.1",
-        "@renproject/utils": "^3.5.1",
+        "@renproject/chains-bitcoin": "^3.5.2",
+        "@renproject/provider": "^3.5.2",
+        "@renproject/utils": "^3.5.2",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/provider",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "description": "Official Ren JavaScript client",
     "repository": {
         "type": "git",
@@ -43,7 +43,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.1",
+        "@renproject/utils": "^3.5.2",
         "axios": "0.27.2",
         "bignumber.js": "9.0.2"
     },

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/provider",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "description": "Official Ren JavaScript client",
     "repository": {
         "type": "git",
@@ -43,7 +43,7 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/utils": "^3.5.0",
+        "@renproject/utils": "^3.5.1",
         "axios": "0.27.2",
         "bignumber.js": "9.0.2"
     },

--- a/packages/provider/src/rpc/jsonRpc.ts
+++ b/packages/provider/src/rpc/jsonRpc.ts
@@ -1,10 +1,4 @@
-import {
-    defaultLogger,
-    Logger,
-    LogLevel,
-    SyncOrPromise,
-    utils,
-} from "@renproject/utils";
+import { defaultLogger, Logger, SyncOrPromise, utils } from "@renproject/utils";
 import axios, { AxiosResponse } from "axios";
 
 const generatePayload = (method: string, params?: unknown) => ({
@@ -79,16 +73,7 @@ export class JsonRpcProvider<
 
         const payload = generatePayload(method, request);
 
-        if (
-            // Check level before doing expensive JSON call.
-            this.logger.getLevel &&
-            this.logger.getLevel() <= LogLevel.Debug
-        ) {
-            this.logger.debug(
-                "[request]",
-                JSON.stringify(payload, null, "    "),
-            );
-        }
+        this.logger.debug("[request]", JSON.stringify(payload, null, "    "));
         try {
             const response = await utils.tryNTimes(
                 async () =>
@@ -117,15 +102,11 @@ export class JsonRpcProvider<
             if (response.data.result === undefined) {
                 throw new Error(`Empty result returned from node.`);
             }
-            if (
-                this.logger.getLevel &&
-                this.logger.getLevel() <= LogLevel.Debug
-            ) {
-                this.logger.debug(
-                    "[response]",
-                    JSON.stringify(response.data.result, null, "    "),
-                );
-            }
+            this.logger.debug(
+                "[response]",
+                JSON.stringify(response.data.result, null, "    "),
+            );
+
             return response.data.result;
         } catch (error: unknown) {
             // Emit debug log of the endpoint and payload.

--- a/packages/provider/src/rpcUrls.ts
+++ b/packages/provider/src/rpcUrls.ts
@@ -3,11 +3,9 @@ import { RenNetwork } from "@renproject/utils";
 export const renRpcUrls = {
     [RenNetwork.Mainnet]: "https://rpc.renproject.io",
     [RenNetwork.Testnet]: "https://rpc-testnet.renproject.io",
-    [RenNetwork.Devnet]: "https://lightnode-devnet.herokuapp.com/",
 };
 
 export const renExplorerUrls = {
     [RenNetwork.Mainnet]: "https://explorer.renproject.io",
     [RenNetwork.Testnet]: "https://explorer-testnet.renproject.io",
-    [RenNetwork.Devnet]: "",
 };

--- a/packages/ren/package.json
+++ b/packages/ren/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "description": "Official Ren JavaScript SDK for bridging crypto assets cross-chain.",
     "repository": {
         "type": "git",
@@ -56,8 +56,8 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/provider": "^3.5.0",
-        "@renproject/utils": "^3.5.0",
+        "@renproject/provider": "^3.5.1",
+        "@renproject/utils": "^3.5.1",
         "bignumber.js": "9.0.2",
         "events": "3.3.0",
         "immutable": "4.1.0"

--- a/packages/ren/package.json
+++ b/packages/ren/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/ren",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "description": "Official Ren JavaScript SDK for bridging crypto assets cross-chain.",
     "repository": {
         "type": "git",
@@ -56,8 +56,8 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@renproject/provider": "^3.5.1",
-        "@renproject/utils": "^3.5.1",
+        "@renproject/provider": "^3.5.2",
+        "@renproject/utils": "^3.5.2",
         "bignumber.js": "9.0.2",
         "events": "3.3.0",
         "immutable": "4.1.0"

--- a/packages/ren/src/utils/config.ts
+++ b/packages/ren/src/utils/config.ts
@@ -37,7 +37,6 @@ export const defaultRenJSConfig = {
 };
 
 // Check that defaultRenJSConfig is a valid RenJSConfig object, while
-// still allowing typescript to infer its type from is value.
-// Therefore it knows that `defaultRenJSConfig.logger` is not potentially
-// undefined.
+// still allowing typescript to infer its type from is value, so that it knows
+// that `defaultRenJSConfig.logger` is not potentially undefined.
 const _check: RenJSConfig = defaultRenJSConfig;

--- a/packages/ren/src/utils/inputAndOutputTypes.ts
+++ b/packages/ren/src/utils/inputAndOutputTypes.ts
@@ -24,7 +24,19 @@ export const getInputAndOutputTypes = async ({
     outputType: OutputType;
     selector: string;
 }> => {
-    if (await toChain.isLockAsset(asset)) {
+    const [
+        isLockAssetOnFromChain,
+        isLockAssetOnToChain,
+        isMintAssetOnFromChain,
+        isMintAssetOnToChain,
+    ] = await Promise.all([
+        fromChain.isLockAsset(asset),
+        toChain.isLockAsset(asset),
+        isContractChain(fromChain) && fromChain.isMintAsset(asset),
+        isContractChain(toChain) && toChain.isMintAsset(asset),
+    ]);
+
+    if (isLockAssetOnToChain) {
         // Burn and release
 
         if (!isContractChain(fromChain)) {
@@ -35,7 +47,7 @@ export const getInputAndOutputTypes = async ({
                 RenJSError.PARAMETER_ERROR,
             );
         }
-        if (!(await fromChain.isMintAsset(asset))) {
+        if (!isMintAssetOnFromChain) {
             throw ErrorWithCode.updateError(
                 new Error(
                     `Asset '${asset}' is not supported on ${fromChain.chain}.`,
@@ -48,7 +60,7 @@ export const getInputAndOutputTypes = async ({
             outputType: OutputType.Release,
             selector: `${asset}/from${fromChain.chain}`,
         };
-    } else if (await fromChain.isLockAsset(asset)) {
+    } else if (isLockAssetOnFromChain) {
         // Lock and mint
 
         if (!isContractChain(toChain)) {
@@ -59,7 +71,7 @@ export const getInputAndOutputTypes = async ({
                 RenJSError.PARAMETER_ERROR,
             );
         }
-        if (!(await toChain.isMintAsset(asset))) {
+        if (!isMintAssetOnToChain) {
             throw ErrorWithCode.updateError(
                 new Error(
                     `Asset '${asset}' is not supported on ${toChain.chain}.`,
@@ -83,7 +95,7 @@ export const getInputAndOutputTypes = async ({
                 RenJSError.PARAMETER_ERROR,
             );
         }
-        if (!(await toChain.isMintAsset(asset))) {
+        if (!isMintAssetOnToChain) {
             throw ErrorWithCode.updateError(
                 new Error(
                     `Asset '${asset}' is not supported on ${toChain.chain}.`,
@@ -100,7 +112,7 @@ export const getInputAndOutputTypes = async ({
                 RenJSError.PARAMETER_ERROR,
             );
         }
-        if (!(await fromChain.isMintAsset(asset))) {
+        if (!isMintAssetOnFromChain) {
             throw ErrorWithCode.updateError(
                 new Error(
                     `Asset '${asset}' is not supported on ${fromChain.chain}.`,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/utils",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@renproject/utils",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renproject/ren-js.git"

--- a/packages/utils/src/common.ts
+++ b/packages/utils/src/common.ts
@@ -28,8 +28,8 @@ export const decodeRenVMSelector = (
     const regex =
         // Regular Expression to match selectors in the form of
         // ASSET/fromCHAINtoCHAIN, ASSET/fromCHAIN or ASSET/toCHAIN.
-        // ^(  ASSET )/[      [from(        CHAIN      ) _   to(   CHAIN  )] OR [from( CHAIN )] OR ( to(  CHAIN  ))]$
-        /^([a-zA-Z]+)\/(?:(?:(?:from([a-zA-Z]+?(?=_to)))\_(?:to([a-zA-Z]+))?)|(?:from([a-zA-Z]+))|(?:to([a-zA-Z]+)))$/;
+        // ^(  ASSET  )/[      [from(        CHAIN      ) _   to(   CHAIN  )] OR [from( CHAIN )] OR ( to(  CHAIN  ))]$
+        /^([a-zA-Z_]+)\/(?:(?:(?:from([a-zA-Z]+?(?=_to)))\_(?:to([a-zA-Z]+))?)|(?:from([a-zA-Z]+))|(?:to([a-zA-Z]+)))$/;
     const match = regex.exec(selector);
     if (!match) {
         throw new Error(`Invalid selector format '${selector}'.`);

--- a/packages/utils/src/types/renNetwork.ts
+++ b/packages/utils/src/types/renNetwork.ts
@@ -1,7 +1,6 @@
 export enum RenNetwork {
     Mainnet = "mainnet",
     Testnet = "testnet",
-    Devnet = "devnet",
 }
 
 export type RenNetworkString = `${RenNetwork}`;

--- a/test/gateway.spec.ts
+++ b/test/gateway.spec.ts
@@ -1,4 +1,4 @@
-import { Solana } from "@renproject/chains";
+import { Moonbeam, Solana } from "@renproject/chains";
 import { getERC20Instance } from "@renproject/chains-ethereum/src/contracts";
 import BigNumber from "bignumber.js";
 import chai from "chai";
@@ -20,6 +20,7 @@ import RenJS from "packages/ren/src";
 import { GatewayParams } from "packages/ren/src/params";
 import { RenNetwork } from "packages/utils/src";
 
+import { LogLevel } from "../packages/ren/build/utils/config";
 import { defaultGatewayHandler } from "./utils/defaultGatewayHandler";
 import { initializeChain } from "./utils/testUtils";
 
@@ -425,16 +426,16 @@ describe("Gateway", () => {
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
     }).timeout(100000000000);
 
-    it.only("AVAX/toGoerli", async () => {
+    it("AVAX/fromKava", async () => {
         const network = RenNetwork.Testnet;
-        const renJS = new RenJS(network);
+        const renJS = new RenJS(network, { logLevel: LogLevel.Debug });
 
         const asset = Avalanche.assets.AVAX;
-        const from = initializeChain(Avalanche, network);
-        const to = initializeChain(Goerli, network);
+        const from = initializeChain(Moonbeam, network);
+        const to = initializeChain(Avalanche, network);
         renJS.withChains(to, from);
 
-        const amount = new BigNumber(1).shiftedBy(18);
+        const amount = new BigNumber(0.001).shiftedBy(18);
 
         // const fees = await renJS.getFees({
         //     asset,
@@ -442,19 +443,18 @@ describe("Gateway", () => {
         //     to: to,
         // });
 
+        console.log(await to.signer.getAddress());
+
         const gatewayParams: GatewayParams = {
             asset: asset,
             from: from.Account({ amount }),
-            // from: from.Transaction({
-            //     txid: "VKzZnqT-sO9kKt43HgCE4Jc18Zd3q5pHddDwK2-2Xw9QMSfqGKS6g-QcPNVMcKMddf16nC0wQf3y25UQU1eeCg",
-            // }),
-            to: to.Address(await to.signer.getAddress()),
+            to: to.Account(),
         };
 
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
     }).timeout(100000000000);
 
-    it.skip("USDT/toCatalog", async () => {
+    it.only("USDT/toCatalog", async () => {
         const network = RenNetwork.Testnet;
 
         const from = initializeChain(Goerli, network);
@@ -468,46 +468,46 @@ describe("Gateway", () => {
             polygon,
         );
 
-        console.log(await catalog.getRenAsset(from.assets.DAI));
+        // console.log(await catalog.getRenAsset(from.assets.DAI));
 
-        console.log(await from.signer!.getAddress());
+        // console.log(await from.signer!.getAddress());
 
-        console.log(
-            Goerli.assets.USDT,
-            (await from.getBalance(Goerli.assets.USDT))
-                .shiftedBy(-(await from.assetDecimals(Goerli.assets.USDT)))
-                .toFixed(),
-        );
-        console.log(
-            Goerli.assets.DAI,
-            (await from.getBalance(Goerli.assets.DAI))
-                .shiftedBy(-(await from.assetDecimals(Goerli.assets.DAI)))
-                .toFixed(),
-        );
-        console.log(
-            Goerli.assets.USDC,
-            (await from.getBalance(Goerli.assets.USDC))
-                .shiftedBy(-(await from.assetDecimals(Goerli.assets.USDC)))
-                .toFixed(),
-        );
+        // console.log(
+        //     Goerli.assets.USDT,
+        //     (await from.getBalance(Goerli.assets.USDT))
+        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets.USDT)))
+        //         .toFixed(),
+        // );
+        // console.log(
+        //     Goerli.assets.DAI,
+        //     (await from.getBalance(Goerli.assets.DAI))
+        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets.DAI)))
+        //         .toFixed(),
+        // );
+        // console.log(
+        //     Goerli.assets.USDC,
+        //     (await from.getBalance(Goerli.assets.USDC))
+        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets.USDC)))
+        //         .toFixed(),
+        // );
 
         const options: Array<[string, EthereumBaseChain]> = [
-            // [Goerli.assets.USDT, catalog],
-            // [Goerli.assets.USDC, catalog],
-            // [Goerli.assets.DAI, catalog],
-            [Goerli.assets.USDT, bsc],
-            [Goerli.assets.USDC, bsc],
-            [Goerli.assets.DAI, bsc],
-            [Goerli.assets.USDT, polygon],
-            [Goerli.assets.USDC, polygon],
-            [Goerli.assets.DAI, polygon],
+            [Goerli.assets.USDT, catalog],
+            [Goerli.assets.USDC, catalog],
+            [Goerli.assets.DAI, catalog],
+            // [Goerli.assets.USDT, bsc],
+            // [Goerli.assets.USDC, bsc],
+            // [Goerli.assets.DAI, bsc],
+            // [Goerli.assets.USDT, polygon],
+            // [Goerli.assets.USDC, polygon],
+            // [Goerli.assets.DAI, polygon],
         ];
 
         for (const [asset, to] of options) {
             // const asset = Ethereum.assets.USDT;
             const decimals = await from.assetDecimals(asset);
 
-            const amount = 100.2;
+            const amount = 10.2;
 
             const gatewayParams = {
                 asset,

--- a/test/gateway.spec.ts
+++ b/test/gateway.spec.ts
@@ -59,7 +59,7 @@ describe("Gateway", () => {
 
     it("recover", async () => {
         const network = RenNetwork.Mainnet;
-        const asset = Ethereum.assets.ETH;
+        const asset = Ethereum.assets[network].ETH;
         const from = initializeChain(Ethereum, network);
         const to = initializeChain(Catalog, network, {
             preserveAddressFormat: true,
@@ -122,7 +122,7 @@ describe("Gateway", () => {
         const network = RenNetwork.Testnet;
         const renJS = new RenJS(network);
 
-        const asset = Ethereum.assets.DAI;
+        const asset = Ethereum.assets[network].DAI;
         const from = initializeChain(Ethereum, network);
         const to = initializeChain(Avalanche, network);
 
@@ -201,7 +201,7 @@ describe("Gateway", () => {
     it("ETH: Ethereum to Arbitrum", async () => {
         const network = RenNetwork.Testnet;
 
-        const asset = Ethereum.assets.ETH;
+        const asset = Ethereum.assets[network].ETH;
         const from = initializeChain(Ethereum, network);
         const to = initializeChain(Arbitrum, network);
 
@@ -218,7 +218,7 @@ describe("Gateway", () => {
 
     it("FIL/toPolygon", async () => {
         const network = RenNetwork.Testnet;
-        const asset = Filecoin.assets.FIL;
+        const asset = Filecoin.assets[network].FIL;
         const from = initializeChain(Filecoin, network);
         const to = initializeChain(Polygon, network);
         const renJS = new RenJS(network).withChains(from, to);
@@ -253,7 +253,7 @@ describe("Gateway", () => {
     it("FIL/fromSolana", async () => {
         const network = RenNetwork.Testnet;
 
-        const asset = Filecoin.assets.FIL;
+        const asset = Filecoin.assets[network].FIL;
         const from = initializeChain(Solana, network);
         const to = initializeChain(Filecoin, network);
 
@@ -277,7 +277,7 @@ describe("Gateway", () => {
     it("DOGE/fromSolana", async () => {
         const network = RenNetwork.Testnet;
 
-        const asset = Dogecoin.assets.DOGE;
+        const asset = Dogecoin.assets[network].DOGE;
         const from = initializeChain(Solana, network);
         const to = initializeChain(Dogecoin, network);
 
@@ -299,7 +299,7 @@ describe("Gateway", () => {
 
     // it("LUNA/toSolana", async () => {
     //     const network = RenNetwork.Testnet;
-    //     const asset = Terra.assets.LUNA;
+    //     const asset = Terra.assets[network].LUNA;
     //     const from = initializeChain<Terra>(Terra);
     //     const to = initializeChain(Solana, network);
     //     const renJS = new RenJS(network).withChains(from, to);
@@ -322,7 +322,7 @@ describe("Gateway", () => {
         //     const network = RenNetwork.Testnet;
         //     const renJS = new RenJS(network);
 
-        //     const asset = Terra.assets.LUNA;
+        //     const asset = Terra.assets[network].LUNA;
         //     const solana = initializeChain(Solana, network);
         //     const terra = initializeChain<Terra>(Terra);
         //     renJS.withChains(terra, solana);
@@ -347,7 +347,7 @@ describe("Gateway", () => {
 
         it("AVAX/toSolana", async () => {
             const network = RenNetwork.Testnet;
-            const asset = Avalanche.assets.AVAX;
+            const asset = Avalanche.assets[network].AVAX;
             const from = initializeChain(Avalanche, network);
             const to = initializeChain(Solana, network);
             const renJS = new RenJS(network).withChains(from, to);
@@ -399,7 +399,7 @@ describe("Gateway", () => {
 
     it.skip("DOGE/toSolana", async () => {
         const network = RenNetwork.Testnet;
-        const asset = Dogecoin.assets.DOGE;
+        const asset = Dogecoin.assets[network].DOGE;
         const from = initializeChain(Dogecoin, network);
         const to = initializeChain(Solana, network);
         const renJS = new RenJS(network).withChains(from, to);
@@ -426,12 +426,12 @@ describe("Gateway", () => {
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
     }).timeout(100000000000);
 
-    it("gETH/toCatalog", async () => {
+    it.only("ETH/toCatalog", async () => {
         const network = RenNetwork.Testnet;
         const renJS = new RenJS(network, { logLevel: LogLevel.Debug });
 
-        const asset = Goerli.assets.gETH;
-        const from = initializeChain(Goerli, network);
+        const asset = Goerli.assets[network].ETH;
+        const from = initializeChain(Ethereum, network);
         const to = initializeChain(Catalog, network);
         renJS.withChains(to, from);
 
@@ -449,7 +449,10 @@ describe("Gateway", () => {
 
         const gatewayParams: GatewayParams = {
             asset: asset,
-            from: from.Account({ amount }),
+            from: from.Account({
+                amount,
+                payloadConfig: { detectPreviousDeposits: true },
+            }),
             to: to.Account(),
         };
 
@@ -475,38 +478,38 @@ describe("Gateway", () => {
         // console.log(await from.signer!.getAddress());
 
         // console.log(
-        //     Goerli.assets.USDT,
-        //     (await from.getBalance(Goerli.assets.USDT))
-        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets.USDT)))
+        //     Goerli.assets[network].USDT,
+        //     (await from.getBalance(Goerli.assets[network].USDT))
+        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets[network].USDT)))
         //         .toFixed(),
         // );
         // console.log(
-        //     Goerli.assets.DAI,
-        //     (await from.getBalance(Goerli.assets.DAI))
-        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets.DAI)))
+        //     Goerli.assets[network].DAI,
+        //     (await from.getBalance(Goerli.assets[network].DAI))
+        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets[network].DAI)))
         //         .toFixed(),
         // );
         // console.log(
-        //     Goerli.assets.USDC,
-        //     (await from.getBalance(Goerli.assets.USDC))
-        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets.USDC)))
+        //     Goerli.assets[network].USDC,
+        //     (await from.getBalance(Goerli.assets[network].USDC))
+        //         .shiftedBy(-(await from.assetDecimals(Goerli.assets[network].USDC)))
         //         .toFixed(),
         // );
 
         const options: Array<[string, EthereumBaseChain]> = [
-            [Goerli.assets.USDT, catalog],
-            [Goerli.assets.USDC, catalog],
-            [Goerli.assets.DAI, catalog],
-            // [Goerli.assets.USDT, bsc],
-            // [Goerli.assets.USDC, bsc],
-            // [Goerli.assets.DAI, bsc],
-            // [Goerli.assets.USDT, polygon],
-            // [Goerli.assets.USDC, polygon],
-            // [Goerli.assets.DAI, polygon],
+            [Goerli.assets[network].USDT, catalog],
+            [Goerli.assets[network].USDC, catalog],
+            [Goerli.assets[network].DAI, catalog],
+            // [Goerli.assets[network].USDT, bsc],
+            // [Goerli.assets[network].USDC, bsc],
+            // [Goerli.assets[network].DAI, bsc],
+            // [Goerli.assets[network].USDT, polygon],
+            // [Goerli.assets[network].USDC, polygon],
+            // [Goerli.assets[network].DAI, polygon],
         ];
 
         for (const [asset, to] of options) {
-            // const asset = Ethereum.assets.USDT;
+            // const asset = Ethereum.assets[network].USDT;
             const decimals = await from.assetDecimals(asset);
 
             const amount = 10.2;
@@ -558,7 +561,7 @@ describe("Gateway", () => {
         const options: EthereumBaseChain[] = [catalog, bsc, polygon, ethereum];
 
         for (const to of options) {
-            // const asset = Ethereum.assets.USDT;
+            // const asset = Ethereum.assets[network].USDT;
 
             const gatewayParams = {
                 asset,
@@ -587,7 +590,7 @@ describe("Gateway", () => {
     it("REN/toSolana", async () => {
         const network = RenNetwork.Testnet;
 
-        const asset = Ethereum.assets.REN;
+        const asset = Ethereum.assets[network].REN;
         const from = initializeChain(Solana, network);
         const to = initializeChain(Ethereum, network);
 
@@ -607,7 +610,7 @@ describe("Gateway", () => {
     it("DAI/toBinanceSmartChain", async () => {
         const network = RenNetwork.Testnet;
 
-        const asset = Ethereum.assets.DAI;
+        const asset = Ethereum.assets[network].DAI;
         const ethereum = initializeChain(Ethereum, network);
         const bsc = initializeChain(BinanceSmartChain, network);
 

--- a/test/gateway.spec.ts
+++ b/test/gateway.spec.ts
@@ -1,4 +1,4 @@
-import { Moonbeam, Solana } from "@renproject/chains";
+import { Solana } from "@renproject/chains";
 import { getERC20Instance } from "@renproject/chains-ethereum/src/contracts";
 import BigNumber from "bignumber.js";
 import chai from "chai";
@@ -426,16 +426,18 @@ describe("Gateway", () => {
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
     }).timeout(100000000000);
 
-    it("AVAX/fromKava", async () => {
+    it("gETH/toCatalog", async () => {
         const network = RenNetwork.Testnet;
         const renJS = new RenJS(network, { logLevel: LogLevel.Debug });
 
-        const asset = Avalanche.assets.AVAX;
-        const from = initializeChain(Moonbeam, network);
-        const to = initializeChain(Avalanche, network);
+        const asset = Goerli.assets.gETH;
+        const from = initializeChain(Goerli, network);
+        const to = initializeChain(Catalog, network);
         renJS.withChains(to, from);
 
-        const amount = new BigNumber(0.001).shiftedBy(18);
+        const decimals = await from.assetDecimals(asset);
+
+        const amount = new BigNumber(0.001).shiftedBy(decimals);
 
         // const fees = await renJS.getFees({
         //     asset,
@@ -454,7 +456,7 @@ describe("Gateway", () => {
         await defaultGatewayHandler(await renJS.gateway(gatewayParams));
     }).timeout(100000000000);
 
-    it.only("USDT/toCatalog", async () => {
+    it("USDT/toCatalog", async () => {
         const network = RenNetwork.Testnet;
 
         const from = initializeChain(Goerli, network);

--- a/test/utils/defaultGatewayHandler.ts
+++ b/test/utils/defaultGatewayHandler.ts
@@ -118,7 +118,7 @@ export const defaultGatewayHandler = async (
                 gateway.gatewayAddress
             } (to receive at least ${receivedAmount.toFixed()})`,
         );
-        const SEND_FUNDS = false;
+        const SEND_FUNDS = true;
         if (SEND_FUNDS) {
             try {
                 await sendFunds(

--- a/test/utils/testUtils.ts
+++ b/test/utils/testUtils.ts
@@ -172,7 +172,7 @@ export const sendFunds = async (
         Buffer.from(utils.fromHex(process.env.TESTNET_PRIVATE_KEY)),
         {
             network: "testnet",
-            apiAddress: "https://multichain-web-proxy.herokuapp.com/testnet",
+            apiAddress: "https://api.calibration.node.glif.io",
             terra: {
                 URL: "https://bombay-fcd.terra.dev",
             },

--- a/test/utils/testUtils.ts
+++ b/test/utils/testUtils.ts
@@ -101,7 +101,7 @@ export const initializeChain = <T extends ChainCommon>(
                         INFURA_API_KEY: process.env.INFURA_KEY,
                     },
                 ),
-                defaultTestnet: "kovan",
+                defaultTestnet: "goerli",
                 config,
             }) as ChainCommon as T;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,20 +290,20 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
-"@ethersproject/abi@5.6.4":
-  version "5.6.4"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.4.tgz#f6e01b6ed391a505932698ecc0d9e7a99ee60362"
-  integrity sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==
+"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
+  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
   dependencies:
-    "@ethersproject/address" "^5.6.1"
-    "@ethersproject/bignumber" "^5.6.2"
-    "@ethersproject/bytes" "^5.6.1"
-    "@ethersproject/constants" "^5.6.1"
-    "@ethersproject/hash" "^5.6.1"
-    "@ethersproject/keccak256" "^5.6.1"
-    "@ethersproject/logger" "^5.6.0"
-    "@ethersproject/properties" "^5.6.0"
-    "@ethersproject/strings" "^5.6.1"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@ethersproject/abstract-provider@5.6.1", "@ethersproject/abstract-provider@^5.6.1":
   version "5.6.1"
@@ -318,6 +318,19 @@
     "@ethersproject/transactions" "^5.6.2"
     "@ethersproject/web" "^5.6.1"
 
+"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
+  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+
 "@ethersproject/abstract-signer@5.6.2", "@ethersproject/abstract-signer@^5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz#491f07fc2cbd5da258f46ec539664713950b0b33"
@@ -328,6 +341,17 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
+  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/address@5.6.1", "@ethersproject/address@^5.6.1":
   version "5.6.1"
@@ -340,12 +364,30 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/rlp" "^5.6.1"
 
+"@ethersproject/address@5.7.0", "@ethersproject/address@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
 "@ethersproject/base64@5.6.1", "@ethersproject/base64@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.1.tgz#2c40d8a0310c9d1606c2c37ae3092634b41d87cb"
   integrity sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==
   dependencies:
     "@ethersproject/bytes" "^5.6.1"
+
+"@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
+  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
 
 "@ethersproject/basex@5.6.1", "@ethersproject/basex@^5.6.1":
   version "5.6.1"
@@ -354,6 +396,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
+  integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/bignumber@5.6.2", "@ethersproject/bignumber@^5.6.2":
   version "5.6.2"
@@ -364,6 +414,15 @@
     "@ethersproject/logger" "^5.6.0"
     bn.js "^5.2.1"
 
+"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@5.6.1", "@ethersproject/bytes@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
@@ -371,12 +430,26 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/constants@5.6.1", "@ethersproject/constants@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.1.tgz#e2e974cac160dd101cf79fdf879d7d18e8cb1370"
   integrity sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==
   dependencies:
     "@ethersproject/bignumber" "^5.6.2"
+
+"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
 
 "@ethersproject/contracts@5.6.2":
   version "5.6.2"
@@ -394,6 +467,22 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.2"
 
+"@ethersproject/contracts@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
+  integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+
 "@ethersproject/hash@5.6.1", "@ethersproject/hash@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.1.tgz#224572ea4de257f05b4abf8ae58b03a67e99b0f4"
@@ -407,6 +496,21 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
+
+"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
+  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@ethersproject/hdnode@5.6.2", "@ethersproject/hdnode@^5.6.2":
   version "5.6.2"
@@ -425,6 +529,24 @@
     "@ethersproject/strings" "^5.6.1"
     "@ethersproject/transactions" "^5.6.2"
     "@ethersproject/wordlists" "^5.6.1"
+
+"@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.7.0.tgz#e627ddc6b466bc77aebf1a6b9e47405ca5aef9cf"
+  integrity sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
 
 "@ethersproject/json-wallets@5.6.1", "@ethersproject/json-wallets@^5.6.1":
   version "5.6.1"
@@ -445,6 +567,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz#5e3355287b548c32b368d91014919ebebddd5360"
+  integrity sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/keccak256@5.6.1", "@ethersproject/keccak256@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.1.tgz#b867167c9b50ba1b1a92bccdd4f2d6bd168a91cc"
@@ -453,10 +594,23 @@
     "@ethersproject/bytes" "^5.6.1"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.6.0", "@ethersproject/logger@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
   integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
+
+"@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
 "@ethersproject/networks@5.6.3", "@ethersproject/networks@^5.6.3":
   version "5.6.3"
@@ -465,12 +619,12 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/networks@5.6.4":
-  version "5.6.4"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.4.tgz#51296d8fec59e9627554f5a8a9c7791248c8dc07"
-  integrity sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==
+"@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
+  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
-    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/pbkdf2@5.6.1", "@ethersproject/pbkdf2@^5.6.1":
   version "5.6.1"
@@ -480,12 +634,27 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/sha2" "^5.6.1"
 
+"@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz#d2267d0a1f6e123f3771007338c47cccd83d3102"
+  integrity sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+
 "@ethersproject/properties@5.6.0", "@ethersproject/properties@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
   integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
   dependencies:
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/properties@5.7.0", "@ethersproject/properties@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
+  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/providers@5.6.8":
   version "5.6.8"
@@ -513,6 +682,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.7.2":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
+  integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.6.1", "@ethersproject/random@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.1.tgz#66915943981bcd3e11bbd43733f5c3ba5a790255"
@@ -521,6 +716,14 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
+  integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/rlp@5.6.1", "@ethersproject/rlp@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.1.tgz#df8311e6f9f24dcb03d59a2bac457a28a4fe2bd8"
@@ -528,6 +731,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/sha2@5.6.1", "@ethersproject/sha2@^5.5.0", "@ethersproject/sha2@^5.6.1":
   version "5.6.1"
@@ -538,6 +749,15 @@
     "@ethersproject/logger" "^5.6.0"
     hash.js "1.1.7"
 
+"@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
+  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
 "@ethersproject/signing-key@5.6.2", "@ethersproject/signing-key@^5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.6.2.tgz#8a51b111e4d62e5a62aee1da1e088d12de0614a3"
@@ -546,6 +766,18 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
+    bn.js "^5.2.1"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
+  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
     bn.js "^5.2.1"
     elliptic "6.5.4"
     hash.js "1.1.7"
@@ -562,6 +794,18 @@
     "@ethersproject/sha2" "^5.6.1"
     "@ethersproject/strings" "^5.6.1"
 
+"@ethersproject/solidity@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
+  integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/strings@5.6.1", "@ethersproject/strings@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.1.tgz#dbc1b7f901db822b5cafd4ebf01ca93c373f8952"
@@ -570,6 +814,15 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/constants" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/strings@5.7.0", "@ethersproject/strings@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
+  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/transactions@5.6.2", "@ethersproject/transactions@^5.6.2":
   version "5.6.2"
@@ -586,6 +839,21 @@
     "@ethersproject/rlp" "^5.6.1"
     "@ethersproject/signing-key" "^5.6.2"
 
+"@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
+  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+
 "@ethersproject/units@5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.6.1.tgz#ecc590d16d37c8f9ef4e89e2005bda7ddc6a4e6f"
@@ -594,6 +862,15 @@
     "@ethersproject/bignumber" "^5.6.2"
     "@ethersproject/constants" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/units@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
+  integrity sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/wallet@5.6.2":
   version "5.6.2"
@@ -616,6 +893,27 @@
     "@ethersproject/transactions" "^5.6.2"
     "@ethersproject/wordlists" "^5.6.1"
 
+"@ethersproject/wallet@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
+  integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/json-wallets" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
+
 "@ethersproject/web@5.6.1", "@ethersproject/web@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.1.tgz#6e2bd3ebadd033e6fe57d072db2b69ad2c9bdf5d"
@@ -627,6 +925,17 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
+"@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
+  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
+  dependencies:
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/wordlists@5.6.1", "@ethersproject/wordlists@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.6.1.tgz#1e78e2740a8a21e9e99947e47979d72e130aeda1"
@@ -637,6 +946,17 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
+
+"@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.7.0.tgz#8fb2c07185d68c3e09eb3bfd6e779ba2774627f5"
+  integrity sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -4770,41 +5090,41 @@ ethereumjs-util@7.1.5:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@5.6.9:
-  version "5.6.9"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.9.tgz#4e12f8dfcb67b88ae7a78a9519b384c23c576a4d"
-  integrity sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==
+ethers@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
+  integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
   dependencies:
-    "@ethersproject/abi" "5.6.4"
-    "@ethersproject/abstract-provider" "5.6.1"
-    "@ethersproject/abstract-signer" "5.6.2"
-    "@ethersproject/address" "5.6.1"
-    "@ethersproject/base64" "5.6.1"
-    "@ethersproject/basex" "5.6.1"
-    "@ethersproject/bignumber" "5.6.2"
-    "@ethersproject/bytes" "5.6.1"
-    "@ethersproject/constants" "5.6.1"
-    "@ethersproject/contracts" "5.6.2"
-    "@ethersproject/hash" "5.6.1"
-    "@ethersproject/hdnode" "5.6.2"
-    "@ethersproject/json-wallets" "5.6.1"
-    "@ethersproject/keccak256" "5.6.1"
-    "@ethersproject/logger" "5.6.0"
-    "@ethersproject/networks" "5.6.4"
-    "@ethersproject/pbkdf2" "5.6.1"
-    "@ethersproject/properties" "5.6.0"
-    "@ethersproject/providers" "5.6.8"
-    "@ethersproject/random" "5.6.1"
-    "@ethersproject/rlp" "5.6.1"
-    "@ethersproject/sha2" "5.6.1"
-    "@ethersproject/signing-key" "5.6.2"
-    "@ethersproject/solidity" "5.6.1"
-    "@ethersproject/strings" "5.6.1"
-    "@ethersproject/transactions" "5.6.2"
-    "@ethersproject/units" "5.6.1"
-    "@ethersproject/wallet" "5.6.2"
-    "@ethersproject/web" "5.6.1"
-    "@ethersproject/wordlists" "5.6.1"
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/address" "5.7.0"
+    "@ethersproject/base64" "5.7.0"
+    "@ethersproject/basex" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/constants" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/hash" "5.7.0"
+    "@ethersproject/hdnode" "5.7.0"
+    "@ethersproject/json-wallets" "5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/logger" "5.7.0"
+    "@ethersproject/networks" "5.7.1"
+    "@ethersproject/pbkdf2" "5.7.0"
+    "@ethersproject/properties" "5.7.0"
+    "@ethersproject/providers" "5.7.2"
+    "@ethersproject/random" "5.7.0"
+    "@ethersproject/rlp" "5.7.0"
+    "@ethersproject/sha2" "5.7.0"
+    "@ethersproject/signing-key" "5.7.0"
+    "@ethersproject/solidity" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/units" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@ethersproject/web" "5.7.1"
+    "@ethersproject/wordlists" "5.7.0"
 
 ethers@^5.6.2:
   version "5.6.8"


### PR DESCRIPTION
Changelog:

1. Kovan config has been removed because RenVM can no longer process Kovan mints/burns. This makes it easier for integrators to support Goerli.
2. The static fields `Ethereum.assets`, `Bitcoin.assets`, etc. should now be accessed as `Class.assets[network].ASSET` instead of `Class.assets.ASSET` (e.g. `Ethereum.assets[RenNetwork.Mainnet].ETH`).
3. Ethereum payloads can now be provided the option `detectPreviousDeposits` to detect previous ETH, BNB, arbETH, etc. deposits to the generated gateway. e.g. `ethereum.Account({ detectPreviousDeposits: true })`.


In retrospect this should have been a minor version bump instead of a patch, because Kovan has been removed and because the structure of the `Ethereum.assets` static field has been changed.