### PR TITLE
feat: update ethers timeout from default 2 minutes to 30 seconds

### DIFF
--- a/packages/chains/chains-ethereum/src/base.ts
+++ b/packages/chains/chains-ethereum/src/base.ts
@@ -204,7 +204,10 @@ export class EthereumBaseChain
         this.provider = Provider.isProvider(web3Provider)
             ? web3Provider
             : typeof web3Provider === "string"
-            ? new ethers.providers.JsonRpcProvider(web3Provider)
+            ? new ethers.providers.JsonRpcProvider({
+                  url: web3Provider,
+                  timeout: 30 * 1000,
+              })
             : // TODO: Set chainId instead of "any"?
               new ethers.providers.Web3Provider(web3Provider, "any");
         if (!this.signer) {

--- a/packages/chains/chains-ethereum/src/utils/generic.ts
+++ b/packages/chains/chains-ethereum/src/utils/generic.ts
@@ -707,7 +707,11 @@ export const getEVMProvider = (
     signer: EthSigner;
 } => {
     const urls = resolveRpcEndpoints(networkConfig.config.rpcUrls, variables);
-    const provider = new ethers.providers.JsonRpcProvider(urls[0]);
+    console.log(networkConfig.selector, urls);
+    const provider = new ethers.providers.JsonRpcProvider({
+        url: urls[0],
+        timeout: 30 * 1000,
+    });
 
     const signer =
         key.privateKey !== undefined


### PR DESCRIPTION
Changelog:

* update ethers timeout from default 2 minutes to 30 seconds
  * The combination of ethers and an expired infura key seem to cause ethers to hang for minutes each request. To facilitate debugging, this PR updates the timeout to 30 seconds.