### PR TITLE
feat: remove request to validate-mint endpoint

### DIFF
--- a/packages/ren/src/gateway.ts
+++ b/packages/ren/src/gateway.ts
@@ -372,20 +372,6 @@ export class Gateway<
                     gHash: gHash,
                 };
 
-                // Submit the gateway details to the back-up submitGateway
-                // endpoint.
-                void utils
-                    .POST(
-                        "https://validate-mint.herokuapp.com/",
-                        JSON.stringify({
-                            gateway: gatewayAddress,
-                            gatewayDetails,
-                        }),
-                    )
-                    .catch(() => {
-                        /* Ignore error. */
-                    });
-
                 try {
                     // Submit the gateway details to the submitGateway endpoint.
                     await utils.tryNTimes(async () => {


### PR DESCRIPTION
The validate-mint endpoint is a fallback for the ren_submitGateway endpoint built into the lightnode, and is no longer needed.