### PR TITLE
feat: update MockProvider to import existing fee calculation utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "chai": "4.3.6",
         "chalk": "4.1.2",
         "codecov": "3.8.3",
+        "cross-env": "^7.0.3",
         "cz-conventional-changelog": "3.3.0",
         "dotenv": "16.0.1",
         "eslint": "8.21.0",

--- a/packages/mock-provider/package.json
+++ b/packages/mock-provider/package.json
@@ -45,6 +45,7 @@
         "@renproject/chains-bitcoin": "^3.6.0",
         "@renproject/provider": "^3.6.0",
         "@renproject/utils": "^3.6.0",
+        "@renproject/ren": "^3.6.0",
         "@types/elliptic": "6.4.14",
         "bignumber.js": "9.0.2",
         "elliptic": "6.5.4",

--- a/packages/mock-provider/src/MockProvider.ts
+++ b/packages/mock-provider/src/MockProvider.ts
@@ -19,7 +19,7 @@ import {
     ResponseQueryBlockState,
 } from "@renproject/provider/methods/ren_queryBlockState";
 import { Provider } from "@renproject/provider/rpc/jsonRpc";
-import { estimateTransactionFee } from "@renproject/ren/build/utils/fees";
+import { estimateTransactionFee } from "@renproject/ren";
 import {
     Chain,
     decodeRenVMSelector,

--- a/packages/ren/src/index.ts
+++ b/packages/ren/src/index.ts
@@ -17,7 +17,7 @@ import { estimateTransactionFee, GatewayFees } from "./utils/fees";
 
 export { Gateway } from "./gateway";
 export { GatewayTransaction } from "./gatewayTransaction";
-export { GatewayFees } from "./utils/fees";
+export { GatewayFees, estimateTransactionFee } from "./utils/fees";
 export { RenVMTxSubmitter } from "./renVMTxSubmitter";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4349,6 +4349,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4360,7 +4367,7 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Currently, the `MockProvider` class in `@renproject/mock-provider` re-implements fee calculation. This PR updates it to instead import `estimateTransactionFee` from `@renproject/ren`.